### PR TITLE
Add support for underline to FormBuilderDropdown

### DIFF
--- a/lib/src/fields/form_builder_dropdown.dart
+++ b/lib/src/fields/form_builder_dropdown.dart
@@ -19,6 +19,7 @@ class FormBuilderDropdown extends StatefulWidget {
   final int elevation;
   final Widget disabledHint;
   final double iconSize;
+  final Widget underline;
 
   FormBuilderDropdown({
     @required this.attribute,
@@ -36,6 +37,7 @@ class FormBuilderDropdown extends StatefulWidget {
     this.disabledHint,
     this.onChanged,
     this.valueTransformer,
+    this.underline,
   });
 
   @override
@@ -97,6 +99,7 @@ class _FormBuilderDropdownState extends State<FormBuilderDropdown> {
             disabledHint: widget.disabledHint,
             elevation: widget.elevation,
             iconSize: widget.iconSize,
+            underline: widget.underline,
             onChanged: _readonly
                 ? null
                 : (value) {


### PR DESCRIPTION
This PR adds support for `underline` to the `FormBuilderDropdown` widget. Flutter added this to `DropDownButton` ~3 months ago in https://github.com/flutter/flutter/pull/29138