### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Column(
                 "I have read and agree to the terms and conditions"),
             validators: [
               FormBuilderValidators.requiredTrue(
-                errorMessage:
+                errorText:
                     "You must accept terms and conditions to continue",
               ),
             ],


### PR DESCRIPTION
Fix named parameter 'errorMessage' isn't defined error in  FormBuilderValidators.requiredTrue for FormBuilderCheckBox validator.
The 'errorMessage' parameter is renamed to the correct name 'errorText' instead.