### PR TITLE
when call`s `currentstate.value`the value is empty

### DIFF
--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -57,6 +57,7 @@ class FormBuilderState extends State<FormBuilder> {
     if (_fieldKeys[attribute] != null) {
       print("Trying to change value for $attribute to $value");
       _fieldKeys[attribute].currentState.didChange(value);
+      _value[attribute] = _fieldKeys[attribute].currentState.value;
       print(_fieldKeys[attribute].currentState.value);
     }
   }


### PR DESCRIPTION
Because values ​​are not being assigned to the getter.