### PR TITLE
FormBuilderCheckbox: initialValue default  was removed

### DIFF
--- a/lib/src/fields/form_builder_checkbox.dart
+++ b/lib/src/fields/form_builder_checkbox.dart
@@ -22,7 +22,7 @@ class FormBuilderCheckbox extends StatefulWidget {
   FormBuilderCheckbox({
     @required this.attribute,
     @required this.label,
-    this.initialValue = false,
+    this.initialValue,
     this.validators = const [],
     this.readOnly = false,
     this.decoration = const InputDecoration(),


### PR DESCRIPTION
initialValue default  was removed in FormBuilderCheckbox because value provided in _formState.initialValue was ignored