### PR TITLE
pushing cancel on timePicker causes an exception / crash

### DIFF
--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -321,9 +321,9 @@ class _FormBuilderDateTimePickerState extends State<FormBuilderDateTimePicker> {
       case InputType.date:
         return await _showDatePicker(context, currentValue) ?? currentValue;
       case InputType.time:
-        return DateTimeField.convert(
-            await _showTimePicker(context, currentValue) ??
-                TimeOfDay.fromDateTime(currentValue));
+        var newValue = await _showTimePicker(context, currentValue);
+        if(newValue == null && currentValue == null) return null;
+        return DateTimeField.convert(newValue ?? TimeOfDay.fromDateTime(currentValue));
       case InputType.both:
         final date = await _showDatePicker(context, currentValue);
         if (date != null) {


### PR DESCRIPTION
If a user would close the time picker with cancel and there were no current value DateTimeField.convert would try to call .hour on null.

This pr handles null cases properly.