### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ FormBuilderCustomField(
       return InputDecorator(
         decoration: InputDecoration(
           labelText: "Select option",
+          errorText: field.errorText,
           contentPadding:
               EdgeInsets.only(top: 10.0, bottom: 0.0),
           border: InputBorder.none,


### PR DESCRIPTION
This commit improves the README section explaining how to build a custom field, by adding the `errorText` property to the `InputDecoration`. This way a proper validation error message will be shown on any custom field if the validation fails.