### PR TITLE
Return value state with all fields defined in initialValue.

### DIFF
--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -34,7 +34,7 @@ class FormBuilderState extends State<FormBuilder> {
   Map<String, GlobalKey<FormFieldState>> _fieldKeys;
   Map<String, dynamic> _value;
 
-  Map<String, dynamic> get value => _value;
+  Map<String, dynamic> get value => { ...widget.initialValue ?? {}, ..._value };
 
   Map<String, dynamic> get initialValue => widget.initialValue;
 


### PR DESCRIPTION
If for some reason I've define a initialValue with a field without a Field Widget, when I reclaim the value after save, the extra fields is not present. I think is because the _value is not initialized with the initialValue Map.