### PR TITLE
Fix some inconsistencies in controller and focus node disposal

### DIFF
--- a/lib/src/fields/form_builder_text_field.dart
+++ b/lib/src/fields/form_builder_text_field.dart
@@ -182,7 +182,9 @@ class FormBuilderTextFieldState extends State<FormBuilderTextField> {
   @override
   void dispose() {
     _formState?.unregisterFieldKey(widget.attribute);
-    _effectiveController.dispose();
+    if(widget.controller == null) {
+      _effectiveController.dispose();
+    }
     super.dispose();
   }
 }


### PR DESCRIPTION
I'm afraid this patch may break backward compatibility but it seems like bad practice for a widget to  dispose a controller that was passed in as an argument by another widget?