### PR TITLE
Common validation logic

### DIFF
--- a/lib/src/fields/form_builder_checkbox.dart
+++ b/lib/src/fields/form_builder_checkbox.dart
@@ -102,14 +102,8 @@ class _FormBuilderCheckboxState extends State<FormBuilderCheckbox> {
       key: _fieldKey,
       enabled: !_readOnly,
       initialValue: _initialValue,
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {

--- a/lib/src/fields/form_builder_checkbox_list.dart
+++ b/lib/src/fields/form_builder_checkbox_list.dart
@@ -108,14 +108,8 @@ class _FormBuilderCheckboxListState extends State<FormBuilderCheckboxList> {
       key: _fieldKey,
       enabled: !_readOnly,
       initialValue: _initialValue ?? [],
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {

--- a/lib/src/fields/form_builder_chips_choice.dart
+++ b/lib/src/fields/form_builder_chips_choice.dart
@@ -98,14 +98,8 @@ class _FormBuilderChoiceChipState extends State<FormBuilderChoiceChip> {
       key: _fieldKey,
       enabled: !_readOnly,
       initialValue: _initialValue,
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {

--- a/lib/src/fields/form_builder_chips_filter.dart
+++ b/lib/src/fields/form_builder_chips_filter.dart
@@ -112,14 +112,8 @@ class _FormBuilderFilterChipState extends State<FormBuilderFilterChip> {
       key: _fieldKey,
       enabled: !_readOnly,
       initialValue: _initialValue ?? [],
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {

--- a/lib/src/fields/form_builder_chips_input.dart
+++ b/lib/src/fields/form_builder_chips_input.dart
@@ -89,14 +89,8 @@ class _FormBuilderChipsInputState extends State<FormBuilderChipsInput> {
       key: _fieldKey,
       enabled: !_readOnly,
       initialValue: _initialValue ?? [],
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {

--- a/lib/src/fields/form_builder_color_picker.dart
+++ b/lib/src/fields/form_builder_color_picker.dart
@@ -144,14 +144,8 @@ class _FormBuilderColorPickerState extends State<FormBuilderColorPicker> {
       key: _fieldKey,
       enabled: !_readOnly,
       initialValue: _initialValue,
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {

--- a/lib/src/fields/form_builder_country_picker.dart
+++ b/lib/src/fields/form_builder_country_picker.dart
@@ -86,14 +86,8 @@ class _FormBuilderCountryPickerState extends State<FormBuilderCountryPicker> {
       key: _fieldKey,
       enabled: !_readOnly,
       initialValue: _initialValue,
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         dynamic transformed;
         if (widget.valueTransformer != null) {

--- a/lib/src/fields/form_builder_date_range_picker.dart
+++ b/lib/src/fields/form_builder_date_range_picker.dart
@@ -186,14 +186,8 @@ class FormBuilderDateRangePickerState
       key: _fieldKey,
       enabled: !_readOnly,
       initialValue: _initialValue,
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {

--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -274,14 +274,8 @@ class _FormBuilderDateTimePickerState extends State<FormBuilderDateTimePicker> {
           widget.onSaved(transformed ?? value);
         }
       },
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onShowPicker: _onShowPicker,
       onChanged: (val) {
         if (widget.onChanged != null) widget.onChanged(val);

--- a/lib/src/fields/form_builder_dropdown.dart
+++ b/lib/src/fields/form_builder_dropdown.dart
@@ -88,14 +88,8 @@ class _FormBuilderDropdownState extends State<FormBuilderDropdown> {
       key: _fieldKey,
       enabled: !_readOnly,
       initialValue: _initialValue,
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {

--- a/lib/src/fields/form_builder_image_picker.dart
+++ b/lib/src/fields/form_builder_image_picker.dart
@@ -71,14 +71,8 @@ class _FormBuilderImagePickerState extends State<FormBuilderImagePicker> {
       key: _fieldKey,
       enabled: !_readOnly,
       initialValue: _initialValue,
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {

--- a/lib/src/fields/form_builder_phone_field.dart
+++ b/lib/src/fields/form_builder_phone_field.dart
@@ -185,14 +185,8 @@ class FormBuilderPhoneFieldState extends State<FormBuilderPhoneField> {
       key: _fieldKey,
       initialValue: fullNumber,
       autovalidate: widget.autovalidate,
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {
@@ -249,7 +243,7 @@ class FormBuilderPhoneFieldState extends State<FormBuilderPhoneField> {
     );
   }
 
-  Widget _textFieldPrefix(field){
+  Widget _textFieldPrefix(field) {
     return GestureDetector(
       onTap: () {
         FocusScope.of(context).requestFocus(FocusNode());

--- a/lib/src/fields/form_builder_radio.dart
+++ b/lib/src/fields/form_builder_radio.dart
@@ -96,14 +96,8 @@ class _FormBuilderRadioState extends State<FormBuilderRadio> {
       key: _fieldKey,
       enabled: !_readOnly,
       initialValue: _initialValue,
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {

--- a/lib/src/fields/form_builder_radio_group.dart
+++ b/lib/src/fields/form_builder_radio_group.dart
@@ -71,14 +71,8 @@ class _FormBuilderRadioGroupState extends State<FormBuilderRadioGroup> {
       key: _fieldKey,
       enabled: !_readOnly,
       initialValue: _initialValue,
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {
@@ -99,12 +93,16 @@ class _FormBuilderRadioGroupState extends State<FormBuilderRadioGroup> {
           ),
           child: RadioGroup.builder(
             groupValue: field.value,
-            onChanged: _readOnly ? null : (value) {
-              FocusScope.of(context).requestFocus(FocusNode());
-              field.didChange(value);
-              if (widget.onChanged != null) widget.onChanged(value);
-            },
-            items: widget.options.map((option) => option.value).toList(growable: false),
+            onChanged: _readOnly
+                ? null
+                : (value) {
+                    FocusScope.of(context).requestFocus(FocusNode());
+                    field.didChange(value);
+                    if (widget.onChanged != null) widget.onChanged(value);
+                  },
+            items: widget.options
+                .map((option) => option.value)
+                .toList(growable: false),
             itemBuilder: (item) {
               return RadioButtonBuilder(
                 item.toString(),

--- a/lib/src/fields/form_builder_range_slider.dart
+++ b/lib/src/fields/form_builder_range_slider.dart
@@ -77,14 +77,8 @@ class _FormBuilderRangeSliderState extends State<FormBuilderRangeSlider> {
       key: _fieldKey,
       enabled: !_readOnly,
       initialValue: _initialValue,
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {

--- a/lib/src/fields/form_builder_rate.dart
+++ b/lib/src/fields/form_builder_rate.dart
@@ -79,14 +79,8 @@ class _FormBuilderRateState extends State<FormBuilderRate> {
       key: _fieldKey,
       enabled: !_readOnly,
       initialValue: _initialValue,
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {

--- a/lib/src/fields/form_builder_segmented_control.dart
+++ b/lib/src/fields/form_builder_segmented_control.dart
@@ -82,14 +82,8 @@ class _FormBuilderSegmentedControlState
       key: _fieldKey,
       initialValue: _initialValue,
       enabled: !_readOnly,
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {

--- a/lib/src/fields/form_builder_signature_pad.dart
+++ b/lib/src/fields/form_builder_signature_pad.dart
@@ -106,14 +106,8 @@ class _FormBuilderSignaturePadState extends State<FormBuilderSignaturePad> {
       key: _fieldKey,
       enabled: !_readOnly,
       initialValue: _initialValue,
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {

--- a/lib/src/fields/form_builder_slider.dart
+++ b/lib/src/fields/form_builder_slider.dart
@@ -83,14 +83,8 @@ class _FormBuilderSliderState extends State<FormBuilderSlider> {
       key: _fieldKey,
       enabled: !_readOnly,
       initialValue: _initialValue,
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {

--- a/lib/src/fields/form_builder_stepper.dart
+++ b/lib/src/fields/form_builder_stepper.dart
@@ -94,14 +94,8 @@ class _FormBuilderStepperState extends State<FormBuilderStepper> {
       enabled: !_readOnly,
       key: _fieldKey,
       initialValue: _initialValue,
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {

--- a/lib/src/fields/form_builder_switch.dart
+++ b/lib/src/fields/form_builder_switch.dart
@@ -121,14 +121,8 @@ class _FormBuilderSwitchState extends State<FormBuilderSwitch> {
         key: _fieldKey,
         enabled: !_readOnly,
         initialValue: _initialValue ?? false,
-        validator: (val) {
-          for (int i = 0; i < widget.validators.length; i++) {
-            if (widget.validators[i](val) != null) {
-              return widget.validators[i](val);
-            }
-          }
-          return null;
-        },
+        validator: (val) =>
+            FormBuilderValidators.validateValidators(val, widget.validators),
         onSaved: (val) {
           var transformed;
           if (widget.valueTransformer != null) {

--- a/lib/src/fields/form_builder_text_field.dart
+++ b/lib/src/fields/form_builder_text_field.dart
@@ -129,14 +129,8 @@ class FormBuilderTextFieldState extends State<FormBuilderTextField> {
 
     return TextFormField(
       key: _fieldKey,
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {

--- a/lib/src/fields/form_builder_touch_spin.dart
+++ b/lib/src/fields/form_builder_touch_spin.dart
@@ -88,14 +88,8 @@ class _FormBuilderTouchSpinState extends State<FormBuilderTouchSpin> {
       enabled: !_readOnly,
       key: _fieldKey,
       initialValue: _initialValue,
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {

--- a/lib/src/fields/form_builder_typeahead.dart
+++ b/lib/src/fields/form_builder_typeahead.dart
@@ -132,14 +132,8 @@ class _FormBuilderTypeAheadState<T> extends State<FormBuilderTypeAhead<T>> {
 
     return TypeAheadFormField<T>(
       key: _fieldKey,
-      validator: (val) {
-        for (int i = 0; i < widget.validators.length; i++) {
-          if (widget.validators[i](val) != null) {
-            return widget.validators[i](val);
-          }
-        }
-        return null;
-      },
+      validator: (val) =>
+          FormBuilderValidators.validateValidators(val, widget.validators),
       onSaved: (val) {
         var transformed;
         if (widget.valueTransformer != null) {

--- a/lib/src/form_builder_custom_field.dart
+++ b/lib/src/form_builder_custom_field.dart
@@ -87,17 +87,9 @@ class FormBuilderCustomFieldState<T> extends State<FormBuilderCustomField<T>> {
             _formState?.setAttributeValue(widget.attribute, val);
           }
         },
-        validator: (val) {
-          for (int i = 0; i < widget.validators.length; i++) {
-            if (widget.validators[i](val) != null) {
-              return widget.validators[i](val);
-            }
-          }
-          if (widget.formField.validator != null) {
-            return widget.formField.validator(val);
-          }
-          return null;
-        },
+        validator: (val) =>
+            FormBuilderValidators.validateValidators(val, widget.validators) ??
+            widget.formField.validator?.call(val),
         builder:
             widget.formField.builder ?? (FormField<T> field) => Container(),
         enabled: widget.formField.enabled,

--- a/lib/src/form_builder_validators.dart
+++ b/lib/src/form_builder_validators.dart
@@ -199,4 +199,17 @@ class FormBuilderValidators {
       return null;
     };
   }
+
+  /// Common validator method that tests [val] against [validators].  When a
+  /// validation generates an error message, it it returned, otherwise null.
+  static String validateValidators<T>(
+      T val, List<String Function(dynamic)> validators) {
+    for (int i = 0; i < validators.length; i++) {
+      final validatorResult = validators[i](val);
+      if (validatorResult != null) {
+        return validatorResult;
+      }
+    }
+    return null;
+  }
 }


### PR DESCRIPTION
Refactored common validation logic into a single static method that may be reused by each form builder widget.  Also tweaked the validation logic to avoid computing the error result twice.