### PR TITLE
Removed examples/.flutter-plugins-dependencies

### DIFF
--- a/example/.flutter-plugins-dependencies
+++ b/example/.flutter-plugins-dependencies
@@ -1,1 +1,0 @@
-{"_info":"// This is a generated file; do not edit or check into version control.","dependencyGraph":[{"name":"flutter_keyboard_visibility","dependencies":[]},{"name":"flutter_plugin_android_lifecycle","dependencies":[]},{"name":"image_picker","dependencies":["flutter_plugin_android_lifecycle"]},{"name":"phone_number","dependencies":[]}]}


### PR DESCRIPTION
Removed `.flutter-plugins-dependencies` because it is not supposed to be checked in to source code control.