### PR TITLE
Resolves #319

### DIFF
--- a/lib/src/fields/form_builder_typeahead.dart
+++ b/lib/src/fields/form_builder_typeahead.dart
@@ -111,9 +111,10 @@ class _FormBuilderTypeAheadState<T> extends State<FormBuilderTypeAhead<T>> {
             ? _formState.initialValue[widget.attribute]
             : null);
 
-    _initialText = (widget.selectionToTextTransformer != null)
-        ? widget.selectionToTextTransformer(_initialValue ?? '')
-        : _initialValue?.toString() ?? '';
+    _initialText = ((widget.selectionToTextTransformer != null)
+            ? widget.selectionToTextTransformer(_initialValue)
+            : _initialValue?.toString()) ??
+        '';
 
     _typeAheadController.text = _initialText;
 


### PR DESCRIPTION
Corrected the `_initialText` expression for when a `FormBuilderTypeAhead` is used for a non-String value class.