### PR TITLE
Optimizations for CountryPickerUtil.

### DIFF
--- a/lib/src/country_picker_util.dart
+++ b/lib/src/country_picker_util.dart
@@ -2,56 +2,34 @@ import 'package:country_pickers/countries.dart';
 import 'package:country_pickers/country.dart';
 
 class CountryPickerUtil {
+  static Country _getCountryByField(
+      String Function(Country) fieldAccessor, String query) {
+    final queryUpperCase = query.toUpperCase();
+    return countryList.firstWhere(
+        (country) => fieldAccessor(country).toUpperCase() == queryUpperCase,
+        orElse: () => null);
+  }
+
   static Country getCountryByIso3Code(String iso3Code) {
-    try {
-      return countryList.firstWhere(
-        (country) => country.iso3Code.toLowerCase() == iso3Code.toLowerCase(),
-      );
-    } catch (error) {
-      return null;
-    }
+    return _getCountryByField((country) => country.iso3Code, iso3Code);
   }
 
   static Country getCountryByIsoCode(String isoCode) {
-    try {
-      return countryList.firstWhere(
-        (country) => country.isoCode.toLowerCase() == isoCode.toLowerCase(),
-      );
-    } catch (error) {
-      return null;
-    }
+    return _getCountryByField((country) => country.isoCode, isoCode);
   }
 
   static Country getCountryByName(String name) {
-    try {
-      return countryList.firstWhere(
-        (country) => country.name.toLowerCase() == name.toLowerCase(),
-      );
-    } catch (error) {
-      return null;
-    }
+    return _getCountryByField((country) => country.name, name);
   }
 
   static Country getCountryByPhoneCode(String phoneCode) {
-    try {
-      return countryList.firstWhere(
-        (country) => country.phoneCode.toLowerCase() == phoneCode.toLowerCase(),
-      );
-    } catch (error) {
-      return null;
-    }
+    return _getCountryByField((country) => country.phoneCode, phoneCode);
   }
 
   static Country getCountryByCodeOrName(String codeOrName) {
-    var country;
-    country = getCountryByIso3Code(codeOrName);
-    if (country != null) return country;
-    country = getCountryByIsoCode(codeOrName);
-    if (country != null) return country;
-    country = getCountryByName(codeOrName);
-    if (country != null) return country;
-    country = getCountryByPhoneCode(codeOrName);
-    if (country != null) return country;
-    return country;
+    return getCountryByIso3Code(codeOrName) ??
+        getCountryByIsoCode(codeOrName) ??
+        getCountryByName(codeOrName) ??
+        getCountryByPhoneCode(codeOrName);
   }
 }


### PR DESCRIPTION
* Centralized the basic logic into a reusable method.
* Compare _upper case_ (vs _lower case_) values since Country Codes are already upper case, so the original value will be returned and less memory will be consumed.
* Convert the `query` to upper case only once, not for every iteration of the closure.
* Use the `orElse` to avoid `try/catch`.