### PR TITLE
Fixed 'RangeSemanticFormatterCallback' isn't a type. 

### DIFF
--- a/lib/src/fields/form_builder_range_slider.dart
+++ b/lib/src/fields/form_builder_range_slider.dart
@@ -18,7 +18,7 @@ class FormBuilderRangeSlider extends StatefulWidget {
   final ValueChanged<RangeValues> onChangeStart;
   final ValueChanged<RangeValues> onChangeEnd;
   final RangeLabels labels;
-  final RangeSemanticFormatterCallback semanticFormatterCallback;
+  final SemanticFormatterCallback semanticFormatterCallback;
   final FormFieldSetter onSaved;
   final DisplayValues displayValues;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,8 @@ dependencies:
 
   flutter_typeahead: ^1.8.7
   intl: ^0.16.1
-  flutter_chips_input: ^1.9.1
+  flutter_chips_input:
+    git: https://github.com/ryanhz/flutter_chips_input.git
   datetime_picker_formfield: ^1.0.0
   flutter_colorpicker: ^0.3.4
   signature: ^3.2.0


### PR DESCRIPTION
Fixed ../lib/src/fields/form_builder_range_slider.dart:21:9: Error: 'RangeSemanticFormatterCallback' isn't a type.       
  final RangeSemanticFormatterCallback semanticFormatterCallback;                                                  
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
in latest flutter (Flutter (Channel master, 1.21.0-10.0.pre.135))