### PR TITLE
Add flutter 1.20.0 requirement to pubspec

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,7 @@ homepage: https://github.com/danvick/flutter_form_builder
 
 environment:
   sdk: ">=2.6.0 <3.0.0"
+  flutter: ^1.20.0 
 
 dependencies:
   flutter:


### PR DESCRIPTION
Noticed I couldn't build the package on Flutter 1.17.1.

Good to have for future compatibility so that users of older Flutter versions can check out the correct package version which is compatible.