### PR TITLE
Prevent events from happening while picking image

### DIFF
--- a/lib/src/widgets/image_source_sheet.dart
+++ b/lib/src/widgets/image_source_sheet.dart
@@ -39,6 +39,8 @@ class ImageSourceBottomSheet extends StatelessWidget {
   final Widget cameraLabel;
   final Widget galleryLabel;
   final EdgeInsets bottomSheetPadding;
+  
+  bool _isPickingImage = false;
 
   ImageSourceBottomSheet({
     Key key,
@@ -57,6 +59,8 @@ class ImageSourceBottomSheet extends StatelessWidget {
         super(key: key);
 
   Future<void> _onPickImage(ImageSource source) async {
+    if(_isPickingImage) return;
+    _isPickingImage = true;
     final imagePicker = ImagePicker();
     final pickedFile = await imagePicker.getImage(
       source: source,
@@ -65,6 +69,7 @@ class ImageSourceBottomSheet extends StatelessWidget {
       imageQuality: imageQuality,
       preferredCameraDevice: preferredCameraDevice,
     );
+    _isPickingImage = false;
     if (null != pickedFile) {
       if (kIsWeb) {
         if (null != onImage) {
@@ -84,22 +89,24 @@ class ImageSourceBottomSheet extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: bottomSheetPadding,
-      child: Wrap(
-        children: <Widget>[
-          ListTile(
-            leading: cameraIcon,
-            title: cameraLabel,
-            onTap: () => _onPickImage(ImageSource.camera),
-          ),
-          ListTile(
-            leading: galleryIcon,
-            title: galleryLabel,
-            onTap: () => _onPickImage(ImageSource.gallery),
-          )
-        ],
-      ),
+    return WillPopScope(
+      onWillPop: () async => !_isPickingImage,
+      child: Container(
+        padding: bottomSheetPadding,
+        child: Wrap(
+          children: <Widget>[
+            ListTile(
+              leading: cameraIcon,
+              title: cameraLabel,
+              onTap: () => _onPickImage(ImageSource.camera),
+            ),
+            ListTile(
+              leading: galleryIcon,
+              title: galleryLabel,
+              onTap: () => _onPickImage(ImageSource.gallery),
+            )
+          ],
+        ),
     );
   }
 }


### PR DESCRIPTION
I ran into an issue on iOS with the bottom sheet controls (the select source buttons and dismissal) which were receiving tap events while the camera app was opened.

This resulted in two issues:
- Error 'Cancelled by a second request' when the user taps 'Use Photo' (because a select source button was also receiving the event)
- Weird behaviour if the user taps on the created photo before you tap 'Use Photo' (it was dismissing the bottom sheet, resulting in a second Navigation pop on Image confirm)

The proposed changes may not be the best way to prevent Events from reaching the bottom sheet while the camera is opened, feedback on how to improve this would be very welcome.