### PR TITLE
[Version 4] Fix dropdown label

### DIFF
--- a/lib/src/fields/form_builder_dropdown.dart
+++ b/lib/src/fields/form_builder_dropdown.dart
@@ -265,6 +265,7 @@ class FormBuilderDropdown<T> extends FormBuilderField<T> {
                       ? decoration.floatingLabelBehavior
                       : FloatingLabelBehavior.always,
                 ),
+                isEmpty: state.value == null,
                 child: Row(
                   children: <Widget>[
                     Expanded(


### PR DESCRIPTION
InputDecorator of `FormBuilderDropdown` misses the `isEmpty`-Attribute. Without this attribute, the floating label is always shown, even if there is no value set.