### PR TITLE
add new optional validation behavior: validateOnBlur

### DIFF
--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -101,6 +101,12 @@ class FormBuilder extends StatefulWidget {
   /// [FormState.validate] to validate.
   final bool autovalidate;
 
+  /// If true, form fields will validate if they lose Focus (user has finished editing)
+  /// and - in case of validation errors - on every change. This behavior provides a user experience
+  /// where validation errors will only be shown if the user has finished editing and
+  /// will be dismissed as soon as the error has been corrected.
+  final bool validateOnBlur;
+
   /// An optional Map of field initialValues. Keys correspond to the field's
   /// name and value to the initialValue of the field.
   ///
@@ -114,6 +120,7 @@ class FormBuilder extends StatefulWidget {
     this.readOnly = false,
     this.onChanged,
     this.autovalidate = false,
+    this.validateOnBlur = false,
     this.onWillPop,
     this.initialValue = const {},
   }) : super(key: key);
@@ -142,6 +149,8 @@ class FormBuilderState extends State<FormBuilder> {
   bool get readOnly => widget.readOnly;
 
   bool get autovalidate => widget.autovalidate;
+
+  bool get validateOnBlur => widget.validateOnBlur;
 
   @override
   void initState() {

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -43,6 +43,12 @@ class FormBuilderField<T> extends FormField<T> {
   /// {@macro flutter.widgets.Focus.focusNode}
   final FocusNode focusNode;
 
+  /// If true, form fields will validate if they lose Focus (user has finished editing)
+  /// and - in case of validation errors - on every change. This behavior provides a user experience
+  /// where validation errors will only be shown if the user has finished editing and
+  /// will be dismissed as soon as the error has been corrected.
+  final bool validateOnBlur;
+
   //TODO: implement bool autofocus, ValueChanged<bool> onValidated
 
   FormBuilderField({
@@ -61,6 +67,7 @@ class FormBuilderField<T> extends FormField<T> {
     this.decoration = const InputDecoration(),
     this.onReset,
     this.focusNode,
+    this.validateOnBlur = false,
   }) : super(
           key: key,
           onSaved: onSaved,
@@ -91,6 +98,8 @@ class FormBuilderFieldState<T> extends FormFieldState<T> {
   bool get autovalidate =>
       _touched &&
       (widget.autovalidate || _formBuilderState?.autovalidate == true);
+
+  bool get validateOnBlur => widget.validateOnBlur || _formBuilderState?.validateOnBlur == true;
 
   T get initialValue => _initialValue;
 
@@ -140,6 +149,8 @@ class FormBuilderFieldState<T> extends FormFieldState<T> {
     if (effectiveFocusNode.hasFocus && _touched == false) {
       setState(() => _touched = true);
       print('${widget.name} touched');
+    } else if (validateOnBlur) {
+      validate();
     }
   }
 
@@ -148,6 +159,9 @@ class FormBuilderFieldState<T> extends FormFieldState<T> {
     setState(() => _dirty = true);
     super.didChange(val);
     widget.onChanged?.call(value);
+    if (hasError && validateOnBlur) {
+      validate();
+    }
   }
 
   @override


### PR DESCRIPTION
It will be very difficult to ensure a decent validation behavior using only `autovalidate`. Unfortunately Flutter `FormState` will validate all FormFields on every build-cycle when `autovalidate` is set to true and I don't see a way to modify this in FormBuilder. "Touched"-checks also can not affect this, since we can not override `FormState` build-method.

My suggested solution would be a different approach using another optional validation strategy: `validateOnBlur`.

If true, form fields will validate if they lose Focus (user has finished editing) and - in case of any validation errors - on every change. This behavior provides a user experience where validation errors will only be shown if the user has finished editing and will be dismissed as soon as the error has been corrected.
