### PR TITLE
Refactor to support a common FormBuilderField class.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -378,7 +378,7 @@ class MyHomePageState extends State<MyHomePage> {
                       }
                     },
                   ),
-                  SizedBox(height: 15),
+                  const SizedBox(height: 15),
                   FormBuilderRadioGroup(
                     orientation: GroupedRadioOrientation.wrap,
                     decoration:
@@ -400,13 +400,13 @@ class MyHomePageState extends State<MyHomePage> {
                             ))
                         .toList(growable: false),
                   ),
-                  SizedBox(height: 15),
-                  SizedBox(height: 15),
+                  const SizedBox(height: 15),
+                  const SizedBox(height: 15),
                   FormBuilderSegmentedControl(
-                    decoration:
-                        InputDecoration(labelText: 'Movie Rating (Archer)'),
+                    decoration: const InputDecoration(
+                        labelText: 'Movie Rating (Archer)'),
                     attribute: 'movie_rating',
-                    textStyle: TextStyle(fontWeight: FontWeight.bold),
+                    textStyle: const TextStyle(fontWeight: FontWeight.bold),
                     options: List.generate(5, (i) => i + 1)
                         .map((number) => FormBuilderFieldOption(
                               value: number,
@@ -418,7 +418,7 @@ class MyHomePageState extends State<MyHomePage> {
                         .toList(),
                     onChanged: _onChanged,
                   ),
-                  SizedBox(height: 15),
+                  const SizedBox(height: 15),
                   FormBuilderSwitch(
                     label: Text('I Accept the tems and conditions'),
                     attribute: 'accept_terms_switch',
@@ -451,11 +451,11 @@ class MyHomePageState extends State<MyHomePage> {
                   ),
                   SizedBox(height: 15),
                   FormBuilderCheckboxGroup(
-                    decoration:
-                        InputDecoration(labelText: 'The language of my people'),
+                    decoration: const InputDecoration(
+                        labelText: 'The language of my people'),
                     attribute: 'languages',
                     initialValue: ['Dart'],
-                    options: [
+                    options: const [
                       FormBuilderFieldOption(value: 'Dart'),
                       FormBuilderFieldOption(value: 'Kotlin'),
                       FormBuilderFieldOption(value: 'Java'),
@@ -464,7 +464,7 @@ class MyHomePageState extends State<MyHomePage> {
                     ],
                     onChanged: _onChanged,
                   ),
-                  SizedBox(height: 15),
+                  const SizedBox(height: 15),
                   FormBuilderImagePicker(
                     attribute: 'images',
                     decoration: const InputDecoration(
@@ -540,38 +540,34 @@ class MyHomePageState extends State<MyHomePage> {
                     ],
                   ),
                   SizedBox(height: 15),
-                  FormBuilderCustomField(
+                  FormBuilderCustomField<String>(
                     attribute: 'name',
                     validators: [FormBuilderValidators.required()],
                     initialValue: 'Argentina',
-                    formField: FormField(
-                      enabled: true,
-                      builder: (FormFieldState<dynamic> field) {
-                        return InputDecorator(
-                          decoration: InputDecoration(
-                            labelText: 'FormBuilderCustomField',
-                            contentPadding: const EdgeInsets.only(
-                              top: 10.0,
-                              bottom: 0.0,
-                            ),
-                            border: InputBorder.none,
-                            errorText: field.errorText,
+                    builder: (FormFieldState<String> field) {
+                      return InputDecorator(
+                        decoration: InputDecoration(
+                          labelText: 'FormBuilderCustomField',
+                          contentPadding: const EdgeInsets.only(
+                            top: 10.0,
+                            bottom: 0.0,
                           ),
-                          child: Container(
-                            height: 200,
-                            child: CupertinoPicker(
-                              itemExtent: 30,
-                              children:
-                                  allCountries.map((c) => Text(c)).toList(),
-                              onSelectedItemChanged: (index) {
-                                print(index);
-                                field.didChange(allCountries[index]);
-                              },
-                            ),
+                          border: InputBorder.none,
+                          errorText: field.errorText,
+                        ),
+                        child: Container(
+                          height: 200,
+                          child: CupertinoPicker(
+                            itemExtent: 30,
+                            children: allCountries.map((c) => Text(c)).toList(),
+                            onSelectedItemChanged: (index) {
+                              print(index);
+                              field.didChange(allCountries[index]);
+                            },
                           ),
-                        );
-                      },
-                    ),
+                        ),
+                      );
+                    },
                   ),
                 ],
               ),

--- a/lib/src/fields/form_builder_checkbox.dart
+++ b/lib/src/fields/form_builder_checkbox.dart
@@ -3,14 +3,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
-class FormBuilderCheckbox extends StatefulWidget {
-  final String attribute;
-  final List<FormFieldValidator> validators;
-  final bool initialValue;
-  final bool readOnly;
-  final InputDecoration decoration;
-  final ValueChanged onChanged;
-  final ValueTransformer valueTransformer;
+class FormBuilderCheckbox extends FormBuilderField<bool> {
   final bool leadingInput;
 
   final Widget label;
@@ -19,7 +12,6 @@ class FormBuilderCheckbox extends StatefulWidget {
   final Color checkColor;
   final MaterialTapTargetSize materialTapTargetSize;
   final bool tristate;
-  final FormFieldSetter onSaved;
   final EdgeInsets contentPadding;
   final Color focusColor;
   final Color hoverColor;
@@ -30,64 +22,57 @@ class FormBuilderCheckbox extends StatefulWidget {
 
   FormBuilderCheckbox({
     Key key,
-    @required this.attribute,
+    @required String attribute,
+    bool readOnly = false,
+    AutovalidateMode autovalidateMode,
+    bool enabled = true,
+    bool initialValue,
+    InputDecoration decoration = const InputDecoration(),
+    ValueChanged<bool> onChanged,
+    FormFieldSetter<bool> onSaved,
+    ValueTransformer<bool> valueTransformer,
+    List<FormFieldValidator<bool>> validators = const [],
     @required this.label,
-    this.initialValue,
-    this.validators = const [],
-    this.readOnly = false,
-    this.decoration = const InputDecoration(),
-    this.onChanged,
-    this.valueTransformer,
     this.leadingInput = false,
     this.activeColor,
     this.checkColor,
     this.materialTapTargetSize,
     this.tristate = false,
-    this.onSaved,
-    this.contentPadding = const EdgeInsets.all(0.0),
+    this.contentPadding = EdgeInsets.zero,
     this.focusColor,
     this.hoverColor,
     this.focusNode,
     this.autoFocus = false,
     this.mouseCursor,
     this.visualDensity,
-  }) : super(key: key);
+  }) : super(
+          key: key,
+          attribute: attribute,
+          readOnly: readOnly,
+          autovalidateMode: autovalidateMode,
+          enabled: enabled,
+          initialValue: initialValue,
+          decoration: decoration,
+          onChanged: onChanged,
+          onSaved: onSaved,
+          valueTransformer: valueTransformer,
+          validators: validators,
+        );
 
   @override
   _FormBuilderCheckboxState createState() => _FormBuilderCheckboxState();
 }
 
-class _FormBuilderCheckboxState extends State<FormBuilderCheckbox> {
-  bool _readOnly = false;
-  final GlobalKey<FormFieldState> _fieldKey = GlobalKey<FormFieldState>();
-  FormBuilderState _formState;
-  bool _initialValue;
-
-  @override
-  void initState() {
-    _formState = FormBuilder.of(context);
-    _formState?.registerFieldKey(widget.attribute, _fieldKey);
-    _initialValue = widget.initialValue ??
-        ((_formState?.initialValue?.containsKey(widget.attribute) ?? false)
-            ? _formState.initialValue[widget.attribute]
-            : null);
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    _formState?.unregisterFieldKey(widget.attribute);
-    super.dispose();
-  }
-
-  Widget _checkbox(FormFieldState<dynamic> field) {
+class _FormBuilderCheckboxState
+    extends FormBuilderFieldState<FormBuilderCheckbox, bool, bool> {
+  Widget _checkbox(FormFieldState<bool> field) {
     return Checkbox(
       value: (field.value == null && !widget.tristate) ? false : field.value,
       activeColor: widget.activeColor,
       checkColor: widget.checkColor,
       materialTapTargetSize: widget.materialTapTargetSize,
       tristate: widget.tristate,
-      onChanged: _readOnly
+      onChanged: readOnly
           ? null
           : (bool value) {
               FocusScope.of(context).requestFocus(FocusNode());
@@ -103,40 +88,29 @@ class _FormBuilderCheckboxState extends State<FormBuilderCheckbox> {
     );
   }
 
-  Widget _leading(FormFieldState<dynamic> field) {
+  Widget _leading(FormFieldState<bool> field) {
     if (widget.leadingInput) return _checkbox(field);
     return null;
   }
 
-  Widget _trailing(FormFieldState<dynamic> field) {
+  Widget _trailing(FormFieldState<bool> field) {
     if (!widget.leadingInput) return _checkbox(field);
     return null;
   }
 
   @override
   Widget build(BuildContext context) {
-    _readOnly = _formState?.readOnly == true || widget.readOnly;
-
-    return FormField(
-      key: _fieldKey,
-      enabled: !_readOnly,
-      initialValue: _initialValue,
-      validator: (val) =>
-          FormBuilderValidators.validateValidators(val, widget.validators),
-      onSaved: (val) {
-        var transformed;
-        if (widget.valueTransformer != null) {
-          transformed = widget.valueTransformer(val);
-          _formState?.setAttributeValue(widget.attribute, transformed);
-        } else {
-          _formState?.setAttributeValue(widget.attribute, val);
-        }
-        widget.onSaved?.call(transformed ?? val);
-      },
-      builder: (FormFieldState<dynamic> field) {
+    return FormField<bool>(
+      key: fieldKey,
+      enabled: widget.enabled,
+      initialValue: initialValue,
+      autovalidateMode: widget.autovalidateMode,
+      validator: (val) => validate(val),
+      onSaved: (val) => save(val),
+      builder: (FormFieldState<bool> field) {
         return InputDecorator(
           decoration: widget.decoration.copyWith(
-            enabled: !_readOnly,
+            enabled: widget.enabled,
             errorText: field.errorText,
           ),
           child: ListTile(
@@ -146,7 +120,7 @@ class _FormBuilderCheckboxState extends State<FormBuilderCheckbox> {
             title: widget.label,
             leading: _leading(field),
             trailing: _trailing(field),
-            onTap: _readOnly
+            onTap: readOnly
                 ? null
                 : () {
                     FocusScope.of(context).requestFocus(FocusNode());

--- a/lib/src/fields/form_builder_checkbox_group.dart
+++ b/lib/src/fields/form_builder_checkbox_group.dart
@@ -4,9 +4,7 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_form_builder/src/widgets/grouped_checkbox.dart';
 
 class FormBuilderCheckboxGroup<T> extends FormBuilderField<List<T>> {
-  final InputDecoration decoration;
-  final ValueChanged onChanged;
-  final List<FormBuilderFieldOption> options;
+  final List<FormBuilderFieldOption<T>> options;
   final Color activeColor;
   final Color checkColor;
   final Color focusColor;
@@ -36,14 +34,15 @@ class FormBuilderCheckboxGroup<T> extends FormBuilderField<List<T>> {
   FormBuilderCheckboxGroup({
     Key key,
     @required String attribute,
-    List<T> initialValue,
     bool readOnly = false,
-    this.decoration = const InputDecoration(),
-    this.onChanged,
-    ValueTransformer valueTransformer,
-    bool enabled = true,
-    FormFieldSetter<List<T>> onSaved,
     AutovalidateMode autovalidateMode,
+    bool enabled = true,
+    List<T> initialValue,
+    InputDecoration decoration = const InputDecoration(),
+    ValueChanged<List<T>> onChanged,
+    FormFieldSetter<List<T>> onSaved,
+    ValueTransformer<List<T>> valueTransformer,
+    List<FormFieldValidator<List<T>>> validators = const [],
     @required this.options,
     this.activeColor,
     this.checkColor,
@@ -63,13 +62,15 @@ class FormBuilderCheckboxGroup<T> extends FormBuilderField<List<T>> {
     this.separator,
     this.controlAffinity = ControlAffinity.leading,
     this.orientation = GroupedCheckboxOrientation.wrap,
-    List<FormFieldValidator<List<T>>> validators = const [],
   }) : super(
           key: key,
           attribute: attribute,
+          readOnly: readOnly,
           autovalidateMode: autovalidateMode,
           enabled: enabled,
           initialValue: initialValue,
+          decoration: decoration,
+          onChanged: onChanged,
           onSaved: onSaved,
           valueTransformer: valueTransformer,
           validators: validators,
@@ -77,26 +78,27 @@ class FormBuilderCheckboxGroup<T> extends FormBuilderField<List<T>> {
 
   @override
   _FormBuilderCheckboxGroupState<T> createState() =>
-      _FormBuilderCheckboxGroupState();
+      _FormBuilderCheckboxGroupState<T>();
 }
 
-class _FormBuilderCheckboxGroupState<T>
-    extends FormBuilderFieldState<FormBuilderCheckboxGroup<T>, List<T>> {
+class _FormBuilderCheckboxGroupState<T> extends FormBuilderFieldState<
+    FormBuilderCheckboxGroup<T>, List<T>, List<T>> {
   @override
   Widget build(BuildContext context) {
-    return FormField(
+    return FormField<List<T>>(
       key: fieldKey,
       enabled: widget.enabled,
       initialValue: initialValue,
+      autovalidateMode: widget.autovalidateMode,
       validator: (val) => validate(val),
       onSaved: (val) => save(val),
-      builder: (FormFieldState field) {
+      builder: (FormFieldState<List<T>> field) {
         return InputDecorator(
           decoration: widget.decoration.copyWith(
             enabled: widget.enabled,
             errorText: field.errorText,
           ),
-          child: GroupedCheckbox(
+          child: GroupedCheckbox<T>(
             orientation: widget.orientation,
             value: field.value,
             options: widget.options,

--- a/lib/src/fields/form_builder_checkbox_group.dart
+++ b/lib/src/fields/form_builder_checkbox_group.dart
@@ -3,17 +3,9 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_form_builder/src/widgets/grouped_checkbox.dart';
 
-class FormBuilderCheckboxGroup<T> extends StatefulWidget {
-  final String attribute;
-  final List<FormFieldValidator> validators;
-  final List<T> initialValue;
-  final bool readOnly;
+class FormBuilderCheckboxGroup<T> extends FormBuilderField<List<T>> {
   final InputDecoration decoration;
   final ValueChanged onChanged;
-  final ValueTransformer valueTransformer;
-  final bool enabled;
-  final FormFieldSetter onSaved;
-  final AutovalidateMode autovalidateMode;
   final List<FormBuilderFieldOption> options;
   final Color activeColor;
   final Color checkColor;
@@ -43,15 +35,15 @@ class FormBuilderCheckboxGroup<T> extends StatefulWidget {
 
   FormBuilderCheckboxGroup({
     Key key,
-    @required this.attribute,
-    this.initialValue,
-    this.readOnly = false,
+    @required String attribute,
+    List<T> initialValue,
+    bool readOnly = false,
     this.decoration = const InputDecoration(),
     this.onChanged,
-    this.valueTransformer,
-    this.enabled = true,
-    this.onSaved,
-    this.autovalidateMode,
+    ValueTransformer valueTransformer,
+    bool enabled = true,
+    FormFieldSetter<List<T>> onSaved,
+    AutovalidateMode autovalidateMode,
     @required this.options,
     this.activeColor,
     this.checkColor,
@@ -71,9 +63,16 @@ class FormBuilderCheckboxGroup<T> extends StatefulWidget {
     this.separator,
     this.controlAffinity = ControlAffinity.leading,
     this.orientation = GroupedCheckboxOrientation.wrap,
-    this.validators = const [],
+    List<FormFieldValidator<List<T>>> validators = const [],
   }) : super(
           key: key,
+          attribute: attribute,
+          autovalidateMode: autovalidateMode,
+          enabled: enabled,
+          initialValue: initialValue,
+          onSaved: onSaved,
+          valueTransformer: valueTransformer,
+          validators: validators,
         );
 
   @override
@@ -82,53 +81,19 @@ class FormBuilderCheckboxGroup<T> extends StatefulWidget {
 }
 
 class _FormBuilderCheckboxGroupState<T>
-    extends State<FormBuilderCheckboxGroup> {
-  bool _readOnly = false;
-  final GlobalKey<FormFieldState> _fieldKey = GlobalKey<FormFieldState>();
-  FormBuilderState _formState;
-  dynamic _initialValue;
-
-  @override
-  void initState() {
-    _formState = FormBuilder.of(context);
-    _formState?.registerFieldKey(widget.attribute, _fieldKey);
-    _initialValue = widget.initialValue ??
-        ((_formState?.initialValue?.containsKey(widget.attribute) ?? false)
-            ? _formState.initialValue[widget.attribute]
-            : null);
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    _formState?.unregisterFieldKey(widget.attribute);
-    super.dispose();
-  }
-
+    extends FormBuilderFieldState<FormBuilderCheckboxGroup<T>, List<T>> {
   @override
   Widget build(BuildContext context) {
-    _readOnly = _formState?.readOnly == true || widget.readOnly;
-
     return FormField(
-      key: _fieldKey,
-      enabled: !_readOnly,
-      initialValue: _initialValue,
-      validator: (val) =>
-          FormBuilderValidators.validateValidators(val, widget.validators),
-      onSaved: (val) {
-        var transformed;
-        if (widget.valueTransformer != null) {
-          transformed = widget.valueTransformer(val);
-          _formState?.setAttributeValue(widget.attribute, transformed);
-        } else {
-          _formState?.setAttributeValue(widget.attribute, val);
-        }
-        widget.onSaved?.call(transformed ?? val);
-      },
+      key: fieldKey,
+      enabled: widget.enabled,
+      initialValue: initialValue,
+      validator: (val) => validate(val),
+      onSaved: (val) => save(val),
       builder: (FormFieldState field) {
         return InputDecorator(
           decoration: widget.decoration.copyWith(
-            enabled: !_readOnly,
+            enabled: widget.enabled,
             errorText: field.errorText,
           ),
           child: GroupedCheckbox(
@@ -143,7 +108,8 @@ class _FormBuilderCheckboxGroupState<T>
             focusColor: widget.focusColor,
             checkColor: widget.checkColor,
             materialTapTargetSize: widget.materialTapTargetSize,
-            disabled: _readOnly
+            // TODO Confirm if this should be readOnly or !enabled
+            disabled: readOnly
                 ? widget.options.map((e) => e.value).toList()
                 : widget.disabled,
             hoverColor: widget.hoverColor,

--- a/lib/src/fields/form_builder_chips_choice.dart
+++ b/lib/src/fields/form_builder_chips_choice.dart
@@ -2,17 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
-class FormBuilderChoiceChip extends StatefulWidget {
-  // FormBuilder Settings
-  final String attribute;
-  final List<FormFieldValidator> validators;
-  final dynamic initialValue;
-  final bool readOnly;
-  final InputDecoration decoration;
-  final ValueChanged onChanged;
-  final FormFieldSetter onSaved;
-  final ValueTransformer valueTransformer;
-  final List<FormBuilderFieldOption> options;
+class FormBuilderChoiceChip<T> extends FormBuilderField<T> {
+  final List<FormBuilderFieldOption<T>> options;
 
   // FilterChip Settings
   final double elevation, pressElevation;
@@ -38,15 +29,17 @@ class FormBuilderChoiceChip extends StatefulWidget {
 
   FormBuilderChoiceChip({
     Key key,
-    @required this.attribute,
+    @required String attribute,
+    bool readOnly = false,
+    AutovalidateMode autovalidateMode,
+    bool enabled = true,
+    T initialValue,
+    InputDecoration decoration = const InputDecoration(),
+    ValueChanged<T> onChanged,
+    FormFieldSetter<T> onSaved,
+    ValueTransformer<T> valueTransformer,
+    List<FormFieldValidator<T>> validators = const [],
     @required this.options,
-    this.initialValue,
-    this.validators = const [],
-    this.readOnly = false,
-    this.decoration = const InputDecoration(),
-    this.onChanged,
-    this.valueTransformer,
-    this.onSaved,
     this.selectedColor,
     this.disabledColor,
     this.backgroundColor,
@@ -67,59 +60,40 @@ class FormBuilderChoiceChip extends StatefulWidget {
     this.labelPadding,
     this.labelStyle,
     this.padding,
-  }) : super(key: key);
+  }) : super(
+          key: key,
+          attribute: attribute,
+          readOnly: readOnly,
+          autovalidateMode: autovalidateMode,
+          enabled: enabled,
+          initialValue: initialValue,
+          decoration: decoration,
+          onChanged: onChanged,
+          onSaved: onSaved,
+          valueTransformer: valueTransformer,
+          validators: validators,
+        );
 
   @override
-  _FormBuilderChoiceChipState createState() => _FormBuilderChoiceChipState();
+  _FormBuilderChoiceChipState<T> createState() =>
+      _FormBuilderChoiceChipState<T>();
 }
 
-class _FormBuilderChoiceChipState extends State<FormBuilderChoiceChip> {
-  bool _readOnly = false;
-  final GlobalKey<FormFieldState> _fieldKey = GlobalKey<FormFieldState>();
-  FormBuilderState _formState;
-  dynamic _initialValue;
-
-  @override
-  void initState() {
-    _formState = FormBuilder.of(context);
-    _formState?.registerFieldKey(widget.attribute, _fieldKey);
-    _initialValue = widget.initialValue ??
-        ((_formState?.initialValue?.containsKey(widget.attribute) ?? false)
-            ? _formState.initialValue[widget.attribute]
-            : null);
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    _formState?.unregisterFieldKey(widget.attribute);
-    super.dispose();
-  }
-
+class _FormBuilderChoiceChipState<T>
+    extends FormBuilderFieldState<FormBuilderChoiceChip<T>, T, T> {
   @override
   Widget build(BuildContext context) {
-    _readOnly = _formState?.readOnly == true || widget.readOnly;
-
-    return FormField(
-      key: _fieldKey,
-      enabled: !_readOnly,
-      initialValue: _initialValue,
-      validator: (val) =>
-          FormBuilderValidators.validateValidators(val, widget.validators),
-      onSaved: (val) {
-        var transformed;
-        if (widget.valueTransformer != null) {
-          transformed = widget.valueTransformer(val);
-          _formState?.setAttributeValue(widget.attribute, transformed);
-        } else {
-          _formState?.setAttributeValue(widget.attribute, val);
-        }
-        widget.onSaved?.call(transformed ?? val);
-      },
-      builder: (FormFieldState<dynamic> field) {
+    return FormField<T>(
+      key: fieldKey,
+      enabled: widget.enabled,
+      initialValue: initialValue,
+      autovalidateMode: widget.autovalidateMode,
+      validator: (val) => validate(val),
+      onSaved: (val) => save(val),
+      builder: (FormFieldState<T> field) {
         return InputDecorator(
           decoration: widget.decoration.copyWith(
-            enabled: !_readOnly,
+            enabled: widget.enabled,
             errorText: field.errorText,
           ),
           child: Wrap(
@@ -132,7 +106,7 @@ class _FormBuilderChoiceChipState extends State<FormBuilderChoiceChip> {
               textDirection: widget.textDirection,
               verticalDirection: widget.verticalDirection,
               children: <Widget>[
-                for (FormBuilderFieldOption option in widget.options)
+                for (FormBuilderFieldOption<T> option in widget.options)
                   ChoiceChip(
                     selectedColor: widget.selectedColor,
                     disabledColor: widget.disabledColor,
@@ -145,7 +119,7 @@ class _FormBuilderChoiceChipState extends State<FormBuilderChoiceChip> {
                     materialTapTargetSize: widget.materialTapTargetSize,
                     label: option,
                     selected: field.value == option.value,
-                    onSelected: _readOnly
+                    onSelected: readOnly
                         ? null
                         : (bool selected) {
                             setState(() {

--- a/lib/src/fields/form_builder_chips_input.dart
+++ b/lib/src/fields/form_builder_chips_input.dart
@@ -3,16 +3,8 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_chips_input/flutter_chips_input.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
-class FormBuilderChipsInput<T> extends StatefulWidget {
-  final String attribute;
-  final List<FormFieldValidator> validators;
-  final List<T> initialValue;
-  final bool readOnly;
-  final InputDecoration decoration;
-  final ValueChanged onChanged;
-  final ValueTransformer valueTransformer;
-
-  final ChipsInputSuggestions findSuggestions;
+class FormBuilderChipsInput<T> extends FormBuilderField<List<T>> {
+  final ChipsInputSuggestions<T> findSuggestions;
 
   // final ValueChanged<List<T>> onChanged;
   final ChipsBuilder<T> chipBuilder;
@@ -27,24 +19,26 @@ class FormBuilderChipsInput<T> extends StatefulWidget {
   final bool obscureText;
   final double suggestionsBoxMaxHeight;
   final TextCapitalization textCapitalization;
-  final FormFieldSetter onSaved;
   final FocusNode focusNode;
   final bool allowChipEditing;
   final bool autofocus;
 
   FormBuilderChipsInput({
     Key key,
-    @required this.attribute,
+    @required String attribute,
+    bool readOnly = false,
+    AutovalidateMode autovalidateMode,
+    bool enabled = true,
+    List<T> initialValue,
+    InputDecoration decoration = const InputDecoration(),
+    ValueChanged<List<T>> onChanged,
+    FormFieldSetter<List<T>> onSaved,
+    ValueTransformer<List<T>> valueTransformer,
+    List<FormFieldValidator<List<T>>> validators = const [],
     @required this.chipBuilder,
     @required this.suggestionBuilder,
     @required this.findSuggestions,
-    this.initialValue = const [],
-    this.validators = const [],
-    this.readOnly = false,
-    this.decoration = const InputDecoration(),
     this.maxChips,
-    this.onChanged,
-    this.valueTransformer,
     this.textStyle,
     this.actionLabel,
     this.suggestionsBoxMaxHeight,
@@ -54,66 +48,46 @@ class FormBuilderChipsInput<T> extends StatefulWidget {
     this.keyboardAppearance = Brightness.light,
     this.obscureText = false,
     this.textCapitalization = TextCapitalization.none,
-    this.onSaved,
     this.focusNode,
     this.allowChipEditing = false,
     this.autofocus = false,
-  }) : super(key: key);
+  }) : super(
+          key: key,
+          attribute: attribute,
+          readOnly: readOnly,
+          autovalidateMode: autovalidateMode,
+          enabled: enabled,
+          initialValue: initialValue,
+          decoration: decoration,
+          onChanged: onChanged,
+          onSaved: onSaved,
+          valueTransformer: valueTransformer,
+          validators: validators,
+        );
 
   @override
-  _FormBuilderChipsInputState createState() => _FormBuilderChipsInputState();
+  _FormBuilderChipsInputState<T> createState() =>
+      _FormBuilderChipsInputState<T>();
 }
 
-class _FormBuilderChipsInputState extends State<FormBuilderChipsInput> {
-  bool _readOnly = false;
-  final GlobalKey<FormFieldState> _fieldKey = GlobalKey<FormFieldState>();
-  FormBuilderState _formState;
-  List<dynamic> _initialValue;
-
-  @override
-  void initState() {
-    _formState = FormBuilder.of(context);
-    _formState?.registerFieldKey(widget.attribute, _fieldKey);
-    _initialValue = widget.initialValue ??
-        ((_formState?.initialValue?.containsKey(widget.attribute) ?? false)
-            ? _formState.initialValue[widget.attribute]
-            : null);
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    _formState?.unregisterFieldKey(widget.attribute);
-    super.dispose();
-  }
-
+class _FormBuilderChipsInputState<T>
+    extends FormBuilderFieldState<FormBuilderChipsInput<T>, List<T>, List<T>> {
   @override
   Widget build(BuildContext context) {
-    _readOnly = _formState?.readOnly == true || widget.readOnly;
-
-    return FormField(
-      key: _fieldKey,
-      enabled: !_readOnly,
-      initialValue: _initialValue ?? [],
-      validator: (val) =>
-          FormBuilderValidators.validateValidators(val, widget.validators),
-      onSaved: (val) {
-        var transformed;
-        if (widget.valueTransformer != null) {
-          transformed = widget.valueTransformer(val);
-          _formState?.setAttributeValue(widget.attribute, transformed);
-        } else {
-          _formState?.setAttributeValue(widget.attribute, val);
-        }
-        widget.onSaved?.call(transformed ?? val);
-      },
-      builder: (FormFieldState<dynamic> field) {
-        return ChipsInput(
+    return FormField<List<T>>(
+      key: fieldKey,
+      enabled: widget.enabled,
+      initialValue: initialValue ?? const [],
+      autovalidateMode: widget.autovalidateMode,
+      validator: (val) => validate(val),
+      onSaved: (val) => save(val),
+      builder: (FormFieldState<List<T>> field) {
+        return ChipsInput<T>(
           key: ObjectKey(field.value),
           initialValue: field.value,
-          enabled: !_readOnly,
+          enabled: widget.enabled,
           decoration: widget.decoration.copyWith(
-            enabled: !_readOnly,
+            enabled: widget.enabled,
             errorText: field.errorText,
           ),
           findSuggestions: widget.findSuggestions,

--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -10,8 +10,6 @@ import 'package:intl/intl.dart';
 enum InputType { date, time, both }
 
 class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
-  final InputDecoration decoration;
-
   /// The date/time picker dialogs to show.
   final InputType inputType;
 
@@ -101,11 +99,6 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
   /// this widget.
   final Future<DateTime> Function(BuildContext context) datePicker;
 
-  /// Called whenever the state's value changes, e.g. after picker value(s)
-  /// have been selected or when the field loses focus. To listen for all text
-  /// changes, use the [controller] and [focusNode].
-  final ValueChanged<DateTime> onChanged;
-
   final bool showCursor;
 
   final int minLines;
@@ -142,13 +135,19 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
   FormBuilderDateTimePicker({
     Key key,
     @required String attribute,
-    List<FormFieldValidator<DateTime>> validators = const [],
     bool readOnly = false,
+    AutovalidateMode autovalidateMode,
+    bool enabled = true,
+    DateTime initialValue,
+    InputDecoration decoration = const InputDecoration(),
+    ValueChanged<DateTime> onChanged,
+    FormFieldSetter<DateTime> onSaved,
+    ValueTransformer<DateTime> valueTransformer,
+    List<FormFieldValidator<DateTime>> validators = const [],
     this.inputType = InputType.both,
     this.scrollPadding = const EdgeInsets.all(20.0),
     this.cursorWidth = 2.0,
     this.enableInteractiveSelection = true,
-    this.decoration = const InputDecoration(),
     this.resetIcon = const Icon(Icons.close),
     this.initialTime = const TimeOfDay(hour: 12, minute: 0),
     this.keyboardType = TextInputType.text,
@@ -159,15 +158,11 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
     this.maxLines = 1,
     this.maxLengthEnforced = true,
     this.expands = false,
-    AutovalidateMode autovalidateMode,
-    DateTime initialValue,
     this.format,
     this.firstDate,
     this.lastDate,
-    this.onChanged,
     this.initialDate,
     this.validator,
-    FormFieldSetter<DateTime> onSaved,
     this.onFieldSubmitted,
     this.initialDatePickerMode = DatePickerMode.day,
     this.locale,
@@ -176,10 +171,8 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
     this.controller,
     this.focusNode,
     this.style,
-    bool enabled = true,
     this.maxLength,
     this.inputFormatters,
-    ValueTransformer valueTransformer,
     this.builder,
     this.timePicker,
     this.datePicker,
@@ -209,9 +202,12 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
   }) : super(
           key: key,
           attribute: attribute,
+          readOnly: readOnly,
           autovalidateMode: autovalidateMode,
           enabled: enabled,
           initialValue: initialValue,
+          decoration: decoration,
+          onChanged: onChanged,
           onSaved: onSaved,
           valueTransformer: valueTransformer,
           validators: validators,
@@ -224,8 +220,8 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
       _FormBuilderDateTimePickerState();
 }
 
-class _FormBuilderDateTimePickerState
-    extends FormBuilderFieldState<FormBuilderDateTimePicker, DateTime> {
+class _FormBuilderDateTimePickerState extends FormBuilderFieldState<
+    FormBuilderDateTimePicker, DateTime, DateTime> {
   FocusNode _focusNode;
   TextEditingController _textFieldController;
   DateTime _stateCurrentValue;

--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -9,13 +9,8 @@ import 'package:intl/intl.dart';
 
 enum InputType { date, time, both }
 
-class FormBuilderDateTimePicker extends StatefulWidget {
-  final String attribute;
-  final List<FormFieldValidator> validators;
-  final DateTime initialValue;
-  final bool readOnly;
+class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
   final InputDecoration decoration;
-  final ValueTransformer valueTransformer;
 
   /// The date/time picker dialogs to show.
   final InputType inputType;
@@ -56,10 +51,6 @@ class FormBuilderDateTimePicker extends StatefulWidget {
       "Doesn't work. Use `validators` attribute to provides `List<FormFieldValidator>` for reusability")
   final FormFieldValidator<DateTime> validator;
 
-  /// Called when an enclosing form is saved. The value passed will be `null`
-  /// if [format] fails to parse the text.
-  final FormFieldSetter<DateTime> onSaved;
-
   /// Corresponds to the [showDatePicker()] parameter. Defaults to
   /// [DatePickerMode.day].
   final DatePickerMode initialDatePickerMode;
@@ -90,14 +81,12 @@ class FormBuilderDateTimePicker extends StatefulWidget {
 
   /// Preset the widget's value.
   final bool autofocus;
-  final AutovalidateMode autovalidateMode;
   final bool obscureText;
   final bool autocorrect;
   final bool maxLengthEnforced;
   final int maxLines;
   final int maxLength;
   final List<TextInputFormatter> inputFormatters;
-  final bool enabled;
   final TransitionBuilder builder;
 
   /// Called when the time chooser dialog should be shown. In the future the
@@ -152,9 +141,9 @@ class FormBuilderDateTimePicker extends StatefulWidget {
 
   FormBuilderDateTimePicker({
     Key key,
-    @required this.attribute,
-    this.validators = const [],
-    this.readOnly = false,
+    @required String attribute,
+    List<FormFieldValidator<DateTime>> validators = const [],
+    bool readOnly = false,
     this.inputType = InputType.both,
     this.scrollPadding = const EdgeInsets.all(20.0),
     this.cursorWidth = 2.0,
@@ -170,16 +159,15 @@ class FormBuilderDateTimePicker extends StatefulWidget {
     this.maxLines = 1,
     this.maxLengthEnforced = true,
     this.expands = false,
-    this.autovalidateMode,
-    // this.editable = true,
-    this.initialValue,
+    AutovalidateMode autovalidateMode,
+    DateTime initialValue,
     this.format,
     this.firstDate,
     this.lastDate,
     this.onChanged,
     this.initialDate,
     this.validator,
-    this.onSaved,
+    FormFieldSetter<DateTime> onSaved,
     this.onFieldSubmitted,
     this.initialDatePickerMode = DatePickerMode.day,
     this.locale,
@@ -188,10 +176,10 @@ class FormBuilderDateTimePicker extends StatefulWidget {
     this.controller,
     this.focusNode,
     this.style,
-    this.enabled,
+    bool enabled = true,
     this.maxLength,
     this.inputFormatters,
-    this.valueTransformer,
+    ValueTransformer valueTransformer,
     this.builder,
     this.timePicker,
     this.datePicker,
@@ -218,7 +206,16 @@ class FormBuilderDateTimePicker extends StatefulWidget {
     this.initialEntryMode = DatePickerEntryMode.calendar,
     this.currentDate,
     this.timePickerInitialEntryMode = TimePickerEntryMode.dial,
-  }) : super(key: key);
+  }) : super(
+          key: key,
+          attribute: attribute,
+          autovalidateMode: autovalidateMode,
+          enabled: enabled,
+          initialValue: initialValue,
+          onSaved: onSaved,
+          valueTransformer: valueTransformer,
+          validators: validators,
+        );
 
   final StrutStyle strutStyle;
 
@@ -227,14 +224,11 @@ class FormBuilderDateTimePicker extends StatefulWidget {
       _FormBuilderDateTimePickerState();
 }
 
-class _FormBuilderDateTimePickerState extends State<FormBuilderDateTimePicker> {
-  bool _readOnly = false;
-  final GlobalKey<FormFieldState> _fieldKey = GlobalKey<FormFieldState>();
-  FormBuilderState _formState;
-  DateTime _initialValue;
+class _FormBuilderDateTimePickerState
+    extends FormBuilderFieldState<FormBuilderDateTimePicker, DateTime> {
   FocusNode _focusNode;
   TextEditingController _textFieldController;
-  DateTime stateCurrentValue;
+  DateTime _stateCurrentValue;
 
   DateFormat get dateFormat =>
       widget.format ?? _dateTimeFormats[widget.inputType];
@@ -255,13 +249,7 @@ class _FormBuilderDateTimePickerState extends State<FormBuilderDateTimePicker> {
   @override
   void initState() {
     super.initState();
-    _formState = FormBuilder.of(context);
-    _formState?.registerFieldKey(widget.attribute, _fieldKey);
-    _initialValue = widget.initialValue ??
-        ((_formState?.initialValue?.containsKey(widget.attribute) ?? false)
-            ? _formState.initialValue[widget.attribute]
-            : null);
-    stateCurrentValue = _initialValue;
+    _stateCurrentValue = initialValue;
     _focusNode = widget.focusNode ?? FocusNode();
     _textFieldController = widget.controller ?? TextEditingController();
     // var appLocale = Localizations.localeOf(context);
@@ -271,14 +259,14 @@ class _FormBuilderDateTimePickerState extends State<FormBuilderDateTimePicker> {
       InputType.time: DateFormat.Hm(widget.locale?.toString()),
     };
     _textFieldController.text =
-        _initialValue == null ? '' : dateFormat.format(_initialValue);
+        initialValue == null ? '' : dateFormat.format(initialValue);
     _focusNode.addListener(_handleFocus);
   }
 
   // Hack to avoid manual editing of date - as is in DateTimeField library
   Future<void> _handleFocus() async {
     setState(() {
-      stateCurrentValue = _fieldKey.currentState.value;
+      _stateCurrentValue = fieldKey.currentState.value;
     });
     if (_focusNode.hasFocus) {
       _textFieldController.clear();
@@ -287,7 +275,6 @@ class _FormBuilderDateTimePickerState extends State<FormBuilderDateTimePicker> {
 
   @override
   void dispose() {
-    _formState?.unregisterFieldKey(widget.attribute);
     if (widget.controller == null) {
       _textFieldController.dispose();
     }
@@ -296,29 +283,16 @@ class _FormBuilderDateTimePickerState extends State<FormBuilderDateTimePicker> {
 
   @override
   Widget build(BuildContext context) {
-    _readOnly = _formState?.readOnly == true || widget.readOnly;
-
     return MediaQuery(
       data: MediaQuery.of(context).copyWith(
         alwaysUse24HourFormat: widget.alwaysUse24HourFormat,
       ),
       child: DateTimeField(
-        key: _fieldKey,
-        initialValue: _initialValue,
+        key: fieldKey,
+        initialValue: initialValue,
         format: dateFormat,
-        onSaved: (val) {
-          var value = _fieldKey.currentState.value;
-          var transformed;
-          if (widget.valueTransformer != null) {
-            transformed = widget.valueTransformer(val);
-            _formState?.setAttributeValue(widget.attribute, transformed);
-          } else {
-            _formState?.setAttributeValue(widget.attribute, value);
-          }
-          widget.onSaved?.call(transformed ?? val);
-        },
-        validator: (val) =>
-            FormBuilderValidators.validateValidators(val, widget.validators),
+        onSaved: (val) => save(val),
+        validator: (val) => validate(val),
         onShowPicker: _onShowPicker,
         onChanged: (val) {
           widget.onChanged?.call(val);
@@ -331,7 +305,7 @@ class _FormBuilderDateTimePickerState extends State<FormBuilderDateTimePicker> {
         autofocus: widget.autofocus,
         decoration: widget.decoration,
         readOnly: true,
-        enabled: !_readOnly,
+        enabled: widget.enabled,
         autocorrect: widget.autocorrect,
         controller: _textFieldController,
         focusNode: _focusNode,
@@ -362,7 +336,7 @@ class _FormBuilderDateTimePickerState extends State<FormBuilderDateTimePicker> {
 
   Future<DateTime> _onShowPicker(
       BuildContext context, DateTime currentValue) async {
-    currentValue = stateCurrentValue;
+    currentValue = _stateCurrentValue;
     DateTime newValue;
     switch (widget.inputType) {
       case InputType.date:
@@ -385,7 +359,7 @@ class _FormBuilderDateTimePickerState extends State<FormBuilderDateTimePicker> {
         break;
     }
     newValue = newValue ?? currentValue;
-    _fieldKey.currentState.didChange(newValue);
+    fieldKey.currentState.didChange(newValue);
     return newValue;
   }
 

--- a/lib/src/fields/form_builder_dropdown.dart
+++ b/lib/src/fields/form_builder_dropdown.dart
@@ -2,15 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
-class FormBuilderDropdown<T> extends StatefulWidget {
-  final String attribute;
-  final List<FormFieldValidator<T>> validators;
-  final T initialValue;
-  final bool readOnly;
-  final InputDecoration decoration;
-  final ValueChanged onChanged;
-  final ValueTransformer valueTransformer;
-
+class FormBuilderDropdown<T> extends FormBuilderField<T> {
   final Widget hint;
   final List<DropdownMenuItem<T>> items;
   final bool isExpanded;
@@ -26,98 +18,76 @@ class FormBuilderDropdown<T> extends StatefulWidget {
   final Color iconEnabledColor;
   final bool allowClear;
   final Widget clearIcon;
-  final FormFieldSetter<T> onSaved;
   final double itemHeight;
   final Color focusColor;
   final Color dropdownColor;
   final bool autofocus;
-  final AutovalidateMode autovalidateMode;
   final FocusNode focusNode;
   final VoidCallback onTap;
   final List<Widget> Function(BuildContext) selectedItemBuilder;
 
   FormBuilderDropdown({
     Key key,
-    @required this.attribute,
+    @required String attribute,
+    bool readOnly = false,
+    AutovalidateMode autovalidateMode,
+    bool enabled = true,
+    T initialValue,
+    InputDecoration decoration = const InputDecoration(),
+    ValueChanged<T> onChanged,
+    FormFieldSetter<T> onSaved,
+    ValueTransformer<T> valueTransformer,
+    List<FormFieldValidator<T>> validators = const [],
     @required this.items,
-    this.validators = const [],
-    this.readOnly = false,
-    this.decoration = const InputDecoration(),
     this.isExpanded = true,
     this.isDense = true,
     this.elevation = 8,
     this.iconSize = 24.0,
     this.hint,
-    this.initialValue,
     this.style,
     this.disabledHint,
-    this.onChanged,
-    this.valueTransformer,
     this.underline,
     this.icon,
     this.iconDisabledColor,
     this.iconEnabledColor,
     this.allowClear = false,
     this.clearIcon = const Icon(Icons.close),
-    this.onSaved,
     this.itemHeight,
     this.focusColor,
     this.dropdownColor,
     this.autofocus = false,
-    this.autovalidateMode,
     this.focusNode,
     this.onTap,
     this.selectedItemBuilder,
-  }) : super(key: key) /*: assert(allowClear == true || clearIcon != null)*/;
+  }) : super(
+          key: key,
+          attribute: attribute,
+          readOnly: readOnly,
+          autovalidateMode: autovalidateMode,
+          enabled: enabled,
+          initialValue: initialValue,
+          decoration: decoration,
+          onChanged: onChanged,
+          onSaved: onSaved,
+          valueTransformer: valueTransformer,
+          validators: validators,
+        ) /*: assert(allowClear == true || clearIcon != null)*/;
 
   @override
-  _FormBuilderDropdownState<T> createState() => _FormBuilderDropdownState();
+  _FormBuilderDropdownState<T> createState() => _FormBuilderDropdownState<T>();
 }
 
-class _FormBuilderDropdownState<T> extends State<FormBuilderDropdown<T>> {
-  bool _readOnly = false;
-  final GlobalKey<FormFieldState> _fieldKey = GlobalKey<FormFieldState>();
-  FormBuilderState _formState;
-  T _initialValue;
-
-  @override
-  void initState() {
-    _formState = FormBuilder.of(context);
-    _formState?.registerFieldKey(widget.attribute, _fieldKey);
-    _initialValue = widget.initialValue ??
-        ((_formState?.initialValue?.containsKey(widget.attribute) ?? false)
-            ? _formState?.initialValue[widget.attribute]
-            : null);
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    _formState?.unregisterFieldKey(widget.attribute);
-    super.dispose();
-  }
-
+class _FormBuilderDropdownState<T>
+    extends FormBuilderFieldState<FormBuilderDropdown<T>, T, T> {
   @override
   Widget build(BuildContext context) {
-    _readOnly = _formState?.readOnly == true || widget.readOnly;
-
-    return FormField(
+    return FormField<T>(
+      key: fieldKey,
+      enabled: widget.enabled,
+      initialValue: initialValue,
       autovalidateMode: widget.autovalidateMode,
-      key: _fieldKey,
-      enabled: !_readOnly,
-      initialValue: _initialValue,
-      validator: (val) =>
-          FormBuilderValidators.validateValidators(val, widget.validators),
-      onSaved: (val) {
-        var transformed;
-        if (widget.valueTransformer != null) {
-          transformed = widget.valueTransformer(val);
-          _formState?.setAttributeValue(widget.attribute, transformed);
-        } else {
-          _formState?.setAttributeValue(widget.attribute, val);
-        }
-        widget.onSaved?.call(transformed ?? val);
-      },
+      validator: (val) => validate(val),
+      onSaved: (val) => save(val),
       builder: (FormFieldState<T> field) {
         return InputDecorator(
           decoration: widget.decoration.copyWith(
@@ -153,7 +123,7 @@ class _FormBuilderDropdownState<T> extends State<FormBuilderDropdown<T>> {
                     iconEnabledColor: widget.iconEnabledColor,
                     // ignore: deprecated_member_use_from_same_package
                     underline: widget.underline,
-                    onChanged: _readOnly
+                    onChanged: readOnly
                         ? null
                         : (value) {
                             _changeValue(field, value);
@@ -186,7 +156,7 @@ class _FormBuilderDropdownState<T> extends State<FormBuilderDropdown<T>> {
     );
   }
 
-  void _changeValue(FormFieldState field, value) {
+  void _changeValue(FormFieldState<T> field, value) {
     field.didChange(value);
     widget.onChanged?.call(value);
   }

--- a/lib/src/fields/form_builder_image_picker.dart
+++ b/lib/src/fields/form_builder_image_picker.dart
@@ -6,17 +6,10 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_form_builder/src/widgets/image_source_sheet.dart';
 import 'package:image_picker/image_picker.dart';
 
-class FormBuilderImagePicker extends StatefulWidget {
-  final String attribute;
-  final List<FormFieldValidator> validators;
-  final List initialValue;
-  final bool readOnly;
+// TODO List<File | Uint8List> -- "ImageHolder"?
+class FormBuilderImagePicker extends FormBuilderField<List<dynamic>> {
   @Deprecated('Set the `labelText` within decoration attribute')
   final String labelText;
-  final InputDecoration decoration;
-  final ValueTransformer valueTransformer;
-  final ValueChanged onChanged;
-  final FormFieldSetter onSaved;
 
   final double imageWidth;
   final double imageHeight;
@@ -50,19 +43,21 @@ class FormBuilderImagePicker extends StatefulWidget {
 
   const FormBuilderImagePicker({
     Key key,
-    @required this.attribute,
-    this.initialValue,
+    @required String attribute,
+    bool readOnly = false,
+    AutovalidateMode autovalidateMode,
+    bool enabled = true,
+    List<dynamic> initialValue,
+    InputDecoration decoration = const InputDecoration(),
+    ValueChanged<List<dynamic>> onChanged,
+    FormFieldSetter<List<dynamic>> onSaved,
+    ValueTransformer<List<dynamic>> valueTransformer,
+    List<FormFieldValidator<List<dynamic>>> validators = const [],
     this.defaultImage,
-    this.validators = const [],
-    this.valueTransformer,
     this.labelText,
-    this.onChanged,
     this.imageWidth = 130,
     this.imageHeight = 130,
     this.imageMargin,
-    this.readOnly = false,
-    this.onSaved,
-    this.decoration = const InputDecoration(),
     this.iconColor,
     this.maxHeight,
     this.maxWidth,
@@ -73,72 +68,52 @@ class FormBuilderImagePicker extends StatefulWidget {
     this.galleryIcon = const Icon(Icons.image),
     this.cameraLabel = const Text('Camera'),
     this.galleryLabel = const Text('Gallery'),
-    this.bottomSheetPadding = const EdgeInsets.all(0),
-  }) : super(key: key);
+    this.bottomSheetPadding = EdgeInsets.zero,
+  }) : super(
+          key: key,
+          attribute: attribute,
+          readOnly: readOnly,
+          autovalidateMode: autovalidateMode,
+          enabled: enabled,
+          initialValue: initialValue,
+          decoration: decoration,
+          onChanged: onChanged,
+          onSaved: onSaved,
+          valueTransformer: valueTransformer,
+          validators: validators,
+        );
 
   @override
   _FormBuilderImagePickerState createState() => _FormBuilderImagePickerState();
 }
 
-class _FormBuilderImagePickerState extends State<FormBuilderImagePicker> {
-  bool _readOnly = false;
-  List _initialValue;
-  final GlobalKey<FormFieldState> _fieldKey = GlobalKey<FormFieldState>();
-  FormBuilderState _formState;
-
+class _FormBuilderImagePickerState extends FormBuilderFieldState<
+    FormBuilderImagePicker, List<dynamic>, List<dynamic>> {
   bool get _hasMaxImages {
     if (widget.maxImages == null) {
       return false;
     } else {
-      return /*_fieldKey.currentState.value != null &&*/ _fieldKey
+      return /*_fieldKey.currentState.value != null &&*/ fieldKey
               .currentState.value.length >=
           widget.maxImages;
     }
   }
 
   @override
-  void initState() {
-    _formState = FormBuilder.of(context);
-    _formState?.registerFieldKey(widget.attribute, _fieldKey);
-    _initialValue = List.of(widget.initialValue ??
-        ((_formState?.initialValue?.containsKey(widget.attribute) ?? false)
-            ? _formState.initialValue[widget.attribute]
-            : []));
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    _formState?.unregisterFieldKey(widget.attribute);
-    super.dispose();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    _readOnly = _formState?.readOnly == true || widget.readOnly;
-
     return FormField<List>(
-      key: _fieldKey,
-      enabled: !_readOnly,
-      initialValue: _initialValue,
-      validator: (val) =>
-          FormBuilderValidators.validateValidators(val, widget.validators),
-      onSaved: (val) {
-        var transformed;
-        if (widget.valueTransformer != null) {
-          transformed = widget.valueTransformer(val);
-          _formState?.setAttributeValue(widget.attribute, transformed);
-        } else {
-          _formState?.setAttributeValue(widget.attribute, val);
-        }
-        widget.onSaved?.call(transformed ?? val);
-      },
+      key: fieldKey,
+      enabled: widget.enabled,
+      initialValue: initialValue ?? const [],
+      autovalidateMode: widget.autovalidateMode,
+      validator: (val) => validate(val),
+      onSaved: (val) => save(val),
       builder: (field) {
         var theme = Theme.of(context);
 
         return InputDecorator(
           decoration: widget.decoration.copyWith(
-            enabled: !_readOnly,
+            enabled: widget.enabled,
             errorText: field.errorText,
             // ignore: deprecated_member_use_from_same_package
             labelText: widget.decoration.labelText ?? widget.labelText,
@@ -173,7 +148,7 @@ class _FormBuilderImagePickerState extends State<FormBuilderImagePicker> {
                                         ? Image.file(item, fit: BoxFit.cover)
                                         : item,
                           ),
-                          if (!_readOnly)
+                          if (!readOnly)
                             InkWell(
                               onTap: () {
                                 field.didChange([...field.value]..remove(item));
@@ -198,7 +173,7 @@ class _FormBuilderImagePickerState extends State<FormBuilderImagePicker> {
                         ],
                       );
                     }).toList()),
-                    if (!_readOnly && !_hasMaxImages)
+                    if (!readOnly && !_hasMaxImages)
                       GestureDetector(
                         child: widget.defaultImage != null
                             ? Image(
@@ -210,11 +185,11 @@ class _FormBuilderImagePickerState extends State<FormBuilderImagePicker> {
                                 width: widget.imageWidth,
                                 height: widget.imageHeight,
                                 child: Icon(Icons.camera_enhance,
-                                    color: _readOnly
+                                    color: readOnly
                                         ? theme.disabledColor
                                         : widget.iconColor ??
                                             theme.primaryColor),
-                                color: (_readOnly
+                                color: (readOnly
                                         ? theme.disabledColor
                                         : widget.iconColor ??
                                             theme.primaryColor)

--- a/lib/src/fields/form_builder_radio.dart
+++ b/lib/src/fields/form_builder_radio.dart
@@ -3,76 +3,60 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
 @Deprecated('Prefer using `FormBuilderRadioGroup` instead')
-class FormBuilderRadio extends StatefulWidget {
-  final String attribute;
-  final List<FormFieldValidator> validators;
-  final dynamic initialValue;
-  final bool readOnly;
-  final InputDecoration decoration;
-  final ValueChanged onChanged;
-  final ValueTransformer valueTransformer;
-
+class FormBuilderRadio<T> extends FormBuilderField<T> {
   final bool leadingInput;
-  final List<FormBuilderFieldOption> options;
+  final List<FormBuilderFieldOption<T>> options;
   final MaterialTapTargetSize materialTapTargetSize;
   final Color activeColor;
-  final FormFieldSetter onSaved;
   final EdgeInsets contentPadding;
 
   FormBuilderRadio({
     Key key,
-    @required this.attribute,
+    @required String attribute,
+    bool readOnly = false,
+    AutovalidateMode autovalidateMode,
+    bool enabled = true,
+    T initialValue,
+    InputDecoration decoration = const InputDecoration(),
+    ValueChanged<T> onChanged,
+    FormFieldSetter<T> onSaved,
+    ValueTransformer<T> valueTransformer,
+    List<FormFieldValidator<T>> validators = const [],
     @required this.options,
-    this.initialValue,
-    this.validators = const [],
-    this.readOnly = false,
-    this.decoration = const InputDecoration(),
-    this.onChanged,
-    this.valueTransformer,
     this.leadingInput = false,
     this.materialTapTargetSize,
     this.activeColor,
-    this.onSaved,
-    this.contentPadding = const EdgeInsets.all(0.0),
-  }) : super(key: key);
+    this.contentPadding = EdgeInsets.zero,
+  }) : super(
+          key: key,
+          attribute: attribute,
+          readOnly: readOnly,
+          autovalidateMode: autovalidateMode,
+          enabled: enabled,
+          initialValue: initialValue,
+          decoration: decoration,
+          onChanged: onChanged,
+          onSaved: onSaved,
+          valueTransformer: valueTransformer,
+          validators: validators,
+        );
 
   @override
-  _FormBuilderRadioState createState() => _FormBuilderRadioState();
+  _FormBuilderRadioState<T> createState() => _FormBuilderRadioState<T>();
 }
 
-// ignore: deprecated_member_use_from_same_package
-class _FormBuilderRadioState extends State<FormBuilderRadio> {
-  bool _readOnly = false;
-  final GlobalKey<FormFieldState> _fieldKey = GlobalKey<FormFieldState>();
-  FormBuilderState _formState;
-  dynamic _initialValue;
-
-  @override
-  void initState() {
-    _formState = FormBuilder.of(context);
-    _formState?.registerFieldKey(widget.attribute, _fieldKey);
-    _initialValue = widget.initialValue ??
-        ((_formState?.initialValue?.containsKey(widget.attribute) ?? false)
-            ? _formState.initialValue[widget.attribute]
-            : null);
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    _formState?.unregisterFieldKey(widget.attribute);
-    super.dispose();
-  }
-
-  Widget _radio(FormFieldState<dynamic> field, int i) {
-    return Radio<dynamic>(
+class _FormBuilderRadioState<T>
+    // ignore: deprecated_member_use_from_same_package
+    extends FormBuilderFieldState<FormBuilderRadio<T>, T, T> {
+  Widget _radio(FormFieldState<T> field, int i) {
+    return Radio<T>(
       value: widget.options[i].value,
       groupValue: field.value,
       materialTapTargetSize: widget.materialTapTargetSize,
       activeColor: widget.activeColor,
-      onChanged: _readOnly
+      onChanged: readOnly
           ? null
-          : (dynamic value) {
+          : (T value) {
               FocusScope.of(context).requestFocus(FocusNode());
               field.didChange(value);
               widget.onChanged?.call(value);
@@ -80,35 +64,24 @@ class _FormBuilderRadioState extends State<FormBuilderRadio> {
     );
   }
 
-  Widget _leading(FormFieldState<dynamic> field, int i) {
+  Widget _leading(FormFieldState<T> field, int i) {
     return widget.leadingInput ? _radio(field, i) : null;
   }
 
-  Widget _trailing(FormFieldState<dynamic> field, int i) {
+  Widget _trailing(FormFieldState<T> field, int i) {
     return !widget.leadingInput ? _radio(field, i) : null;
   }
 
   @override
   Widget build(BuildContext context) {
-    _readOnly = _formState?.readOnly == true || widget.readOnly;
-
-    return FormField(
-      key: _fieldKey,
-      enabled: !_readOnly,
-      initialValue: _initialValue,
-      validator: (val) =>
-          FormBuilderValidators.validateValidators(val, widget.validators),
-      onSaved: (val) {
-        var transformed;
-        if (widget.valueTransformer != null) {
-          transformed = widget.valueTransformer(val);
-          _formState?.setAttributeValue(widget.attribute, transformed);
-        } else {
-          _formState?.setAttributeValue(widget.attribute, val);
-        }
-        widget.onSaved?.call(transformed ?? val);
-      },
-      builder: (FormFieldState<dynamic> field) {
+    return FormField<T>(
+      key: fieldKey,
+      enabled: widget.enabled,
+      initialValue: initialValue,
+      autovalidateMode: widget.autovalidateMode,
+      validator: (val) => validate(val),
+      onSaved: (val) => save(val),
+      builder: (FormFieldState<T> field) {
         final radioList = <Widget>[];
         for (var i = 0; i < widget.options.length; i++) {
           radioList.addAll([
@@ -119,7 +92,7 @@ class _FormBuilderRadioState extends State<FormBuilderRadio> {
               leading: _leading(field, i),
               title: widget.options[i],
               trailing: _trailing(field, i),
-              onTap: _readOnly
+              onTap: readOnly
                   ? null
                   : () {
                       final value = widget.options[i].value;
@@ -134,7 +107,7 @@ class _FormBuilderRadioState extends State<FormBuilderRadio> {
         }
         return InputDecorator(
           decoration: widget.decoration.copyWith(
-            enabled: !_readOnly,
+            enabled: widget.enabled,
             errorText: field.errorText,
           ),
           child: Column(

--- a/lib/src/fields/form_builder_radio_group.dart
+++ b/lib/src/fields/form_builder_radio_group.dart
@@ -4,19 +4,10 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_form_builder/src/widgets/grouped_checkbox.dart';
 import 'package:flutter_form_builder/src/widgets/grouped_radio.dart';
 
-class FormBuilderRadioGroup extends StatefulWidget {
-  final String attribute;
-  final List<FormFieldValidator> validators;
-  final dynamic initialValue;
-  final bool readOnly;
-  final InputDecoration decoration;
-  final ValueChanged onChanged;
-  final ValueTransformer valueTransformer;
-
-  final List<FormBuilderFieldOption> options;
+class FormBuilderRadioGroup<T> extends FormBuilderField<T> {
+  final List<FormBuilderFieldOption<T>> options;
   final MaterialTapTargetSize materialTapTargetSize;
   final Color activeColor;
-  final FormFieldSetter onSaved;
   final Color focusColor;
   final Color hoverColor;
   final List disabled;
@@ -39,15 +30,17 @@ class FormBuilderRadioGroup extends StatefulWidget {
 
   FormBuilderRadioGroup({
     Key key,
-    @required this.attribute,
+    @required String attribute,
+    bool readOnly = false,
+    AutovalidateMode autovalidateMode,
+    bool enabled = true,
+    T initialValue,
+    InputDecoration decoration = const InputDecoration(),
+    ValueChanged<T> onChanged,
+    FormFieldSetter<T> onSaved,
+    ValueTransformer<T> valueTransformer,
+    List<FormFieldValidator<T>> validators = const [],
     @required this.options,
-    this.initialValue,
-    this.validators = const [],
-    this.readOnly = false,
-    this.decoration = const InputDecoration(),
-    this.onChanged,
-    this.valueTransformer,
-    this.onSaved,
     this.materialTapTargetSize,
     this.wrapDirection = Axis.horizontal,
     this.wrapAlignment = WrapAlignment.start,
@@ -64,62 +57,43 @@ class FormBuilderRadioGroup extends StatefulWidget {
     this.disabled,
     this.wrapTextDirection,
     this.separator,
-  }) : super(key: key);
+  }) : super(
+          key: key,
+          attribute: attribute,
+          readOnly: readOnly,
+          autovalidateMode: autovalidateMode,
+          enabled: enabled,
+          initialValue: initialValue,
+          decoration: decoration,
+          onChanged: onChanged,
+          onSaved: onSaved,
+          valueTransformer: valueTransformer,
+          validators: validators,
+        );
 
   @override
-  _FormBuilderRadioGroupState createState() => _FormBuilderRadioGroupState();
+  _FormBuilderRadioGroupState<T> createState() =>
+      _FormBuilderRadioGroupState<T>();
 }
 
-class _FormBuilderRadioGroupState extends State<FormBuilderRadioGroup> {
-  bool _readOnly = false;
-  final GlobalKey<FormFieldState> _fieldKey = GlobalKey<FormFieldState>();
-  FormBuilderState _formState;
-  dynamic _initialValue;
-
-  @override
-  void initState() {
-    _formState = FormBuilder.of(context);
-    _formState?.registerFieldKey(widget.attribute, _fieldKey);
-    _initialValue = widget.initialValue ??
-        ((_formState?.initialValue?.containsKey(widget.attribute) ?? false)
-            ? _formState.initialValue[widget.attribute]
-            : null);
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    _formState?.unregisterFieldKey(widget.attribute);
-    super.dispose();
-  }
-
+class _FormBuilderRadioGroupState<T>
+    extends FormBuilderFieldState<FormBuilderRadioGroup<T>, T, T> {
   @override
   Widget build(BuildContext context) {
-    _readOnly = _formState?.readOnly == true || widget.readOnly;
-
-    return FormField(
-      key: _fieldKey,
-      enabled: !_readOnly,
-      initialValue: _initialValue,
-      validator: (val) =>
-          FormBuilderValidators.validateValidators(val, widget.validators),
-      onSaved: (val) {
-        var transformed;
-        if (widget.valueTransformer != null) {
-          transformed = widget.valueTransformer(val);
-          _formState?.setAttributeValue(widget.attribute, transformed);
-        } else {
-          _formState?.setAttributeValue(widget.attribute, val);
-        }
-        widget.onSaved?.call(transformed ?? val);
-      },
-      builder: (FormFieldState<dynamic> field) {
+    return FormField<T>(
+      key: fieldKey,
+      enabled: widget.enabled,
+      initialValue: initialValue,
+      autovalidateMode: widget.autovalidateMode,
+      validator: (val) => validate(val),
+      onSaved: (val) => save(val),
+      builder: (FormFieldState<T> field) {
         return InputDecorator(
           decoration: widget.decoration.copyWith(
-            enabled: !_readOnly,
+            enabled: widget.enabled,
             errorText: field.errorText,
           ),
-          child: GroupedRadio(
+          child: GroupedRadio<T>(
             orientation: widget.orientation,
             value: field.value,
             options: widget.options,
@@ -130,7 +104,7 @@ class _FormBuilderRadioGroupState extends State<FormBuilderRadioGroup> {
             activeColor: widget.activeColor,
             focusColor: widget.focusColor,
             materialTapTargetSize: widget.materialTapTargetSize,
-            disabled: !_readOnly
+            disabled: !readOnly
                 ? widget.disabled
                 : widget.options.map((e) => e.value).toList(),
             hoverColor: widget.hoverColor,

--- a/lib/src/fields/form_builder_range_slider.dart
+++ b/lib/src/fields/form_builder_range_slider.dart
@@ -2,14 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
-class FormBuilderRangeSlider extends StatefulWidget {
-  final String attribute;
-  final List<FormFieldValidator> validators;
-  final RangeValues initialValue;
-  final bool readOnly;
-  final InputDecoration decoration;
-  final ValueChanged onChanged;
-  final ValueTransformer valueTransformer;
+class FormBuilderRangeSlider extends FormBuilderField<RangeValues> {
   final num max;
   final num min;
   final int divisions;
@@ -19,82 +12,63 @@ class FormBuilderRangeSlider extends StatefulWidget {
   final ValueChanged<RangeValues> onChangeEnd;
   final RangeLabels labels;
   final SemanticFormatterCallback semanticFormatterCallback;
-  final FormFieldSetter onSaved;
   final DisplayValues displayValues;
 
   FormBuilderRangeSlider({
     Key key,
-    @required this.attribute,
+    @required String attribute,
+    bool readOnly = false,
+    AutovalidateMode autovalidateMode,
+    bool enabled = true,
+    RangeValues initialValue,
+    InputDecoration decoration = const InputDecoration(),
+    ValueChanged<RangeValues> onChanged,
+    FormFieldSetter<RangeValues> onSaved,
+    ValueTransformer<RangeValues> valueTransformer,
+    List<FormFieldValidator<RangeValues>> validators = const [],
     @required this.min,
     @required this.max,
-    @required this.initialValue,
-    this.validators = const [],
-    this.readOnly = false,
-    this.decoration = const InputDecoration(),
     this.divisions,
-    this.onChanged,
-    this.valueTransformer,
     this.activeColor,
     this.inactiveColor,
     this.onChangeStart,
     this.onChangeEnd,
     this.labels,
     this.semanticFormatterCallback,
-    this.onSaved,
     this.displayValues = DisplayValues.all,
-  }) : super(key: key);
+  }) : super(
+          key: key,
+          attribute: attribute,
+          readOnly: readOnly,
+          autovalidateMode: autovalidateMode,
+          enabled: enabled,
+          initialValue: initialValue,
+          decoration: decoration,
+          onChanged: onChanged,
+          onSaved: onSaved,
+          valueTransformer: valueTransformer,
+          validators: validators,
+        );
 
   @override
   _FormBuilderRangeSliderState createState() => _FormBuilderRangeSliderState();
 }
 
-class _FormBuilderRangeSliderState extends State<FormBuilderRangeSlider> {
-  bool _readOnly = false;
-  final GlobalKey<FormFieldState> _fieldKey = GlobalKey<FormFieldState>();
-  FormBuilderState _formState;
-  RangeValues _initialValue;
-
-  @override
-  void initState() {
-    _formState = FormBuilder.of(context);
-    _formState?.registerFieldKey(widget.attribute, _fieldKey);
-    _initialValue = widget.initialValue ??
-        ((_formState?.initialValue?.containsKey(widget.attribute) ?? false)
-            ? _formState.initialValue[widget.attribute]
-            : null);
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    _formState?.unregisterFieldKey(widget.attribute);
-    super.dispose();
-  }
-
+class _FormBuilderRangeSliderState extends FormBuilderFieldState<
+    FormBuilderRangeSlider, RangeValues, RangeValues> {
   @override
   Widget build(BuildContext context) {
-    _readOnly = _formState?.readOnly == true || widget.readOnly;
-
-    return FormField(
-      key: _fieldKey,
-      enabled: !_readOnly,
-      initialValue: _initialValue,
-      validator: (val) =>
-          FormBuilderValidators.validateValidators(val, widget.validators),
-      onSaved: (val) {
-        var transformed;
-        if (widget.valueTransformer != null) {
-          transformed = widget.valueTransformer(val);
-          _formState?.setAttributeValue(widget.attribute, transformed);
-        } else {
-          _formState?.setAttributeValue(widget.attribute, val);
-        }
-        widget.onSaved?.call(transformed ?? val);
-      },
+    return FormField<RangeValues>(
+      key: fieldKey,
+      enabled: widget.enabled,
+      initialValue: initialValue,
+      autovalidateMode: widget.autovalidateMode,
+      validator: (val) => validate(val),
+      onSaved: (val) => save(val),
       builder: (FormFieldState<RangeValues> field) {
         return InputDecorator(
           decoration: widget.decoration.copyWith(
-            enabled: !_readOnly,
+            enabled: widget.enabled,
             errorText: field.errorText,
           ),
           child: Container(
@@ -113,7 +87,7 @@ class _FormBuilderRangeSliderState extends State<FormBuilderRangeSlider> {
                   onChangeStart: widget.onChangeStart,
                   labels: widget.labels,
                   semanticFormatterCallback: widget.semanticFormatterCallback,
-                  onChanged: _readOnly
+                  onChanged: readOnly
                       ? null
                       : (RangeValues values) {
                           FocusScope.of(context).requestFocus(FocusNode());
@@ -126,11 +100,11 @@ class _FormBuilderRangeSliderState extends State<FormBuilderRangeSlider> {
                     if (widget.displayValues != DisplayValues.none &&
                         widget.displayValues != DisplayValues.current)
                       Text('${widget.min}'),
-                    Spacer(),
+                    const Spacer(),
                     if (widget.displayValues != DisplayValues.none &&
                         widget.displayValues != DisplayValues.minMax)
                       Text('${field.value.start}   -   ${field.value.end}'),
-                    Spacer(),
+                    const Spacer(),
                     if (widget.displayValues != DisplayValues.none &&
                         widget.displayValues != DisplayValues.current)
                       Text('${widget.max}'),

--- a/lib/src/fields/form_builder_segmented_control.dart
+++ b/lib/src/fields/form_builder_segmented_control.dart
@@ -3,24 +3,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
-class FormBuilderSegmentedControl extends StatefulWidget {
-  final String attribute;
-  final List<FormFieldValidator> validators;
-  final dynamic initialValue;
-  final bool readOnly;
-  final InputDecoration decoration;
-  final ValueChanged onChanged;
-  final ValueTransformer valueTransformer;
+class FormBuilderSegmentedControl<T> extends FormBuilderField<T> {
+  final List<FormBuilderFieldOption<T>> options;
+
   final Color borderColor;
   final Color selectedColor;
   final Color pressedColor;
-  final FormFieldSetter onSaved;
 
   @Deprecated(
       "Use `FormBuilderFieldOption`'s `child` property to style your option")
   final TextStyle textStyle;
-
-  final List<FormBuilderFieldOption> options;
 
   final EdgeInsetsGeometry padding;
 
@@ -28,89 +20,71 @@ class FormBuilderSegmentedControl extends StatefulWidget {
 
   FormBuilderSegmentedControl({
     Key key,
-    @required this.attribute,
+    @required String attribute,
+    bool readOnly = false,
+    AutovalidateMode autovalidateMode,
+    bool enabled = true,
+    T initialValue,
+    InputDecoration decoration = const InputDecoration(),
+    ValueChanged<T> onChanged,
+    FormFieldSetter<T> onSaved,
+    ValueTransformer<T> valueTransformer,
+    List<FormFieldValidator<T>> validators = const [],
     @required this.options,
-    this.initialValue,
-    this.validators = const [],
-    this.readOnly = false,
-    this.decoration = const InputDecoration(),
-    this.onChanged,
-    this.valueTransformer,
     this.borderColor,
     this.selectedColor,
     this.pressedColor,
     this.textStyle,
     this.padding,
     this.unselectedColor,
-    this.onSaved,
-  }) : super(key: key);
+  }) : super(
+          key: key,
+          attribute: attribute,
+          readOnly: readOnly,
+          autovalidateMode: autovalidateMode,
+          enabled: enabled,
+          initialValue: initialValue,
+          decoration: decoration,
+          onChanged: onChanged,
+          onSaved: onSaved,
+          valueTransformer: valueTransformer,
+          validators: validators,
+        );
 
   @override
-  _FormBuilderSegmentedControlState createState() =>
-      _FormBuilderSegmentedControlState();
+  _FormBuilderSegmentedControlState<T> createState() =>
+      _FormBuilderSegmentedControlState<T>();
 }
 
-class _FormBuilderSegmentedControlState
-    extends State<FormBuilderSegmentedControl> {
-  bool _readOnly = false;
-  final GlobalKey<FormFieldState> _fieldKey = GlobalKey<FormFieldState>();
-  FormBuilderState _formState;
-  dynamic _initialValue;
-
-  @override
-  void initState() {
-    _formState = FormBuilder.of(context);
-    _formState?.registerFieldKey(widget.attribute, _fieldKey);
-    _initialValue = widget.initialValue ??
-        ((_formState?.initialValue?.containsKey(widget.attribute) ?? false)
-            ? _formState.initialValue[widget.attribute]
-            : null);
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    _formState?.unregisterFieldKey(widget.attribute);
-    super.dispose();
-  }
-
+class _FormBuilderSegmentedControlState<T>
+    extends FormBuilderFieldState<FormBuilderSegmentedControl<T>, T, T> {
   @override
   Widget build(BuildContext context) {
-    _readOnly = _formState?.readOnly == true || widget.readOnly;
     final theme = Theme.of(context);
 
-    return FormField(
-      key: _fieldKey,
-      initialValue: _initialValue,
-      enabled: !_readOnly,
-      validator: (val) =>
-          FormBuilderValidators.validateValidators(val, widget.validators),
-      onSaved: (val) {
-        var transformed;
-        if (widget.valueTransformer != null) {
-          transformed = widget.valueTransformer(val);
-          _formState?.setAttributeValue(widget.attribute, transformed);
-        } else {
-          _formState?.setAttributeValue(widget.attribute, val);
-        }
-        widget.onSaved?.call(transformed ?? val);
-      },
-      builder: (FormFieldState<dynamic> field) {
+    return FormField<T>(
+      key: fieldKey,
+      enabled: widget.enabled,
+      initialValue: initialValue,
+      autovalidateMode: widget.autovalidateMode,
+      validator: (val) => validate(val),
+      onSaved: (val) => save(val),
+      builder: (FormFieldState<T> field) {
         return InputDecorator(
           decoration: widget.decoration.copyWith(
-            enabled: !_readOnly,
+            enabled: widget.enabled,
             errorText: field.errorText,
           ),
           child: Padding(
             padding: const EdgeInsets.only(top: 10.0),
-            child: CupertinoSegmentedControl(
-              borderColor: _readOnly
+            child: CupertinoSegmentedControl<T>(
+              borderColor: readOnly
                   ? theme.disabledColor
                   : widget.borderColor ?? theme.primaryColor,
-              selectedColor: _readOnly
+              selectedColor: readOnly
                   ? theme.disabledColor
                   : widget.selectedColor ?? theme.primaryColor,
-              pressedColor: _readOnly
+              pressedColor: readOnly
                   ? theme.disabledColor
                   : widget.pressedColor ?? theme.primaryColor,
               groupValue: field.value,
@@ -131,9 +105,9 @@ class _FormBuilderSegmentedControlState
               },
               padding: widget.padding,
               unselectedColor: widget.unselectedColor,
-              onValueChanged: (dynamic value) {
+              onValueChanged: (T value) {
                 FocusScope.of(context).requestFocus(FocusNode());
-                if (_readOnly) {
+                if (readOnly) {
                   field.reset();
                 } else {
                   field.didChange(value);

--- a/lib/src/fields/form_builder_stepper.dart
+++ b/lib/src/fields/form_builder_stepper.dart
@@ -5,19 +5,11 @@ import 'package:flutter_touch_spin/flutter_touch_spin.dart';
 import 'package:intl/intl.dart';
 
 @Deprecated('Use `FormBuilderTouchSpin` instead.')
-class FormBuilderStepper extends StatefulWidget {
-  final String attribute;
-  final List<FormFieldValidator> validators;
-  final num initialValue;
-  final bool readOnly;
-  final InputDecoration decoration;
-  final ValueChanged onChanged;
-  final ValueTransformer valueTransformer;
+class FormBuilderStepper extends FormBuilderField<num> {
   final num step;
   final num min;
   final num max;
   final num size;
-  final FormFieldSetter onSaved;
   final Icon subtractIcon;
   final Icon addIcon;
 
@@ -35,18 +27,20 @@ class FormBuilderStepper extends StatefulWidget {
 
   FormBuilderStepper({
     Key key,
-    @required this.attribute,
-    this.initialValue,
-    this.validators = const [],
-    this.readOnly = false,
-    this.decoration = const InputDecoration(),
+    @required String attribute,
+    AutovalidateMode autovalidateMode,
+    bool enabled = true,
+    num initialValue,
+    InputDecoration decoration = const InputDecoration(),
+    ValueChanged<num> onChanged,
+    FormFieldSetter<num> onSaved,
+    bool readOnly = false,
+    ValueTransformer<num> valueTransformer,
+    List<FormFieldValidator<num>> validators = const [],
     this.step,
     this.min = 1,
     this.max = 9999,
     @Deprecated('Use `iconSize` instead') this.size,
-    this.onChanged,
-    this.valueTransformer,
-    this.onSaved,
     this.iconSize = 24.0,
     this.displayFormat,
     this.subtractIcon = const Icon(Icons.remove),
@@ -56,60 +50,40 @@ class FormBuilderStepper extends StatefulWidget {
     this.iconActiveColor,
     this.iconDisabledColor,
   })  : assert(size != null || iconSize != null),
-        super(key: key);
+        super(
+          key: key,
+          attribute: attribute,
+          readOnly: readOnly,
+          autovalidateMode: autovalidateMode,
+          enabled: enabled,
+          initialValue: initialValue,
+          decoration: decoration,
+          onChanged: onChanged,
+          onSaved: onSaved,
+          valueTransformer: valueTransformer,
+          validators: validators,
+        );
 
   @override
   _FormBuilderStepperState createState() => _FormBuilderStepperState();
 }
 
-// ignore: deprecated_member_use_from_same_package
-class _FormBuilderStepperState extends State<FormBuilderStepper> {
-  bool _readOnly = false;
-  final GlobalKey<FormFieldState> _fieldKey = GlobalKey<FormFieldState>();
-  FormBuilderState _formState;
-  num _initialValue;
-
-  @override
-  void initState() {
-    _formState = FormBuilder.of(context);
-    _formState?.registerFieldKey(widget.attribute, _fieldKey);
-    _initialValue = widget.initialValue ??
-        ((_formState?.initialValue?.containsKey(widget.attribute) ?? false)
-            ? _formState.initialValue[widget.attribute]
-            : null);
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    _formState?.unregisterFieldKey(widget.attribute);
-    super.dispose();
-  }
-
+class _FormBuilderStepperState extends
+    // ignore: deprecated_member_use_from_same_package
+    FormBuilderFieldState<FormBuilderStepper, num, num> {
   @override
   Widget build(BuildContext context) {
-    _readOnly = _formState?.readOnly == true || widget.readOnly;
-
-    return FormField(
-      enabled: !_readOnly,
-      key: _fieldKey,
-      initialValue: _initialValue,
-      validator: (val) =>
-          FormBuilderValidators.validateValidators(val, widget.validators),
-      onSaved: (val) {
-        var transformed;
-        if (widget.valueTransformer != null) {
-          transformed = widget.valueTransformer(val);
-          _formState?.setAttributeValue(widget.attribute, transformed);
-        } else {
-          _formState?.setAttributeValue(widget.attribute, val);
-        }
-        widget.onSaved?.call(transformed ?? val);
-      },
-      builder: (FormFieldState<dynamic> field) {
+    return FormField<num>(
+      key: fieldKey,
+      enabled: widget.enabled,
+      initialValue: initialValue,
+      autovalidateMode: widget.autovalidateMode,
+      validator: (val) => validate(val),
+      onSaved: (val) => save(val),
+      builder: (FormFieldState<num> field) {
         return InputDecorator(
           decoration: widget.decoration.copyWith(
-            enabled: !_readOnly,
+            enabled: widget.enabled,
             errorText: field.errorText,
           ),
           child: TouchSpin(
@@ -118,7 +92,7 @@ class _FormBuilderStepperState extends State<FormBuilderStepper> {
             step: widget.step,
             value: field.value,
             iconSize: widget.size ?? widget.iconSize,
-            onChanged: _readOnly
+            onChanged: readOnly
                 ? null
                 : (value) {
                     FocusScope.of(context).requestFocus(FocusNode());
@@ -134,7 +108,7 @@ class _FormBuilderStepperState extends State<FormBuilderStepper> {
             iconDisabledColor:
                 widget.iconDisabledColor ?? Theme.of(context).disabledColor,
             iconPadding: widget.iconPadding,
-            enabled: !_readOnly,
+            enabled: widget.enabled,
           ),
         );
       },

--- a/lib/src/fields/form_builder_switch.dart
+++ b/lib/src/fields/form_builder_switch.dart
@@ -5,9 +5,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
 class FormBuilderSwitch extends FormBuilderField<bool> {
-  final InputDecoration decoration;
-  final ValueChanged onChanged;
-
   final Widget label;
 
   /// The color to use when this switch is on.
@@ -69,15 +66,16 @@ class FormBuilderSwitch extends FormBuilderField<bool> {
   FormBuilderSwitch({
     Key key,
     @required String attribute,
-    @required this.label,
-    bool initialValue,
-    List<FormFieldValidator<bool>> validators = const [],
+    bool readOnly = false,
     AutovalidateMode autovalidateMode,
     bool enabled = true,
-    bool readOnly = false,
-    this.decoration = const InputDecoration(),
-    this.onChanged,
-    ValueTransformer valueTransformer,
+    bool initialValue,
+    InputDecoration decoration = const InputDecoration(),
+    ValueChanged<bool> onChanged,
+    FormFieldSetter<bool> onSaved,
+    ValueTransformer<bool> valueTransformer,
+    List<FormFieldValidator<bool>> validators = const [],
+    @required this.label,
     this.activeColor,
     this.activeTrackColor,
     this.inactiveThumbColor,
@@ -86,8 +84,7 @@ class FormBuilderSwitch extends FormBuilderField<bool> {
     this.inactiveThumbImage,
     this.materialTapTargetSize,
     this.dragStartBehavior = DragStartBehavior.start,
-    FormFieldSetter<bool> onSaved,
-    this.contentPadding = const EdgeInsets.all(0.0),
+    this.contentPadding = EdgeInsets.zero,
     this.mouseCursor,
     this.autofocus = false,
     this.focusNode,
@@ -98,9 +95,12 @@ class FormBuilderSwitch extends FormBuilderField<bool> {
   }) : super(
           key: key,
           attribute: attribute,
+          readOnly: readOnly,
           autovalidateMode: autovalidateMode,
           enabled: enabled,
           initialValue: initialValue,
+          decoration: decoration,
+          onChanged: onChanged,
           onSaved: onSaved,
           valueTransformer: valueTransformer,
           validators: validators,
@@ -111,16 +111,16 @@ class FormBuilderSwitch extends FormBuilderField<bool> {
 }
 
 class _FormBuilderSwitchState
-    extends FormBuilderFieldState<FormBuilderSwitch, bool> {
+    extends FormBuilderFieldState<FormBuilderSwitch, bool, bool> {
   @override
   Widget build(BuildContext context) {
-    return FormField(
+    return FormField<bool>(
         key: fieldKey,
         enabled: widget.enabled,
         initialValue: initialValue ?? false,
         validator: (val) => validate(val),
         onSaved: (val) => save(val),
-        builder: (FormFieldState<dynamic> field) {
+        builder: (FormFieldState<bool> field) {
           return InputDecorator(
             decoration: widget.decoration.copyWith(
               enabled: widget.enabled,

--- a/lib/src/fields/form_builder_text_field.dart
+++ b/lib/src/fields/form_builder_text_field.dart
@@ -5,8 +5,6 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_form_builder/src/always_disabled_focus_node.dart';
 
 class FormBuilderTextField extends FormBuilderField<String> {
-  final InputDecoration decoration;
-  final ValueChanged onChanged;
   final int maxLines;
   final TextInputType keyboardType;
   final bool obscureText;
@@ -48,16 +46,19 @@ class FormBuilderTextField extends FormBuilderField<String> {
   FormBuilderTextField({
     Key key,
     @required String attribute,
-    String initialValue,
-    List<FormFieldValidator<String>> validators = const [],
     bool readOnly = false,
-    this.decoration = const InputDecoration(),
     AutovalidateMode autovalidateMode,
+    bool enabled = true,
+    String initialValue,
+    InputDecoration decoration = const InputDecoration(),
+    ValueChanged<String> onChanged,
+    FormFieldSetter<String> onSaved,
+    ValueTransformer<String> valueTransformer,
+    List<FormFieldValidator<String>> validators = const [],
     this.maxLines = 1,
     this.obscureText = false,
     this.textCapitalization = TextCapitalization.none,
     this.scrollPadding = const EdgeInsets.all(20.0),
-    bool enabled = true,
     this.enableInteractiveSelection = true,
     this.maxLengthEnforced = true,
     this.textAlign = TextAlign.start,
@@ -80,12 +81,9 @@ class FormBuilderTextField extends FormBuilderField<String> {
     this.cursorColor,
     this.keyboardAppearance,
     this.buildCounter,
-    this.onChanged,
-    ValueTransformer valueTransformer,
     this.expands = false,
     this.minLines,
     this.showCursor,
-    FormFieldSetter<String> onSaved,
     this.onTap,
     this.toolbarOptions,
     this.smartQuotesType,
@@ -98,9 +96,12 @@ class FormBuilderTextField extends FormBuilderField<String> {
         super(
           key: key,
           attribute: attribute,
+          readOnly: readOnly,
           autovalidateMode: autovalidateMode,
           enabled: enabled,
           initialValue: initialValue,
+          decoration: decoration,
+          onChanged: onChanged,
           onSaved: onSaved,
           valueTransformer: valueTransformer,
           validators: validators,
@@ -111,23 +112,23 @@ class FormBuilderTextField extends FormBuilderField<String> {
 }
 
 class FormBuilderTextFieldState
-    extends FormBuilderFieldState<FormBuilderTextField, String> {
+    extends FormBuilderFieldState<FormBuilderTextField, String, String> {
   TextEditingController _effectiveController;
 
   @override
   void initState() {
     super.initState();
     _effectiveController =
-        widget.controller ?? TextEditingController(text: initialValue ?? '');
+        widget.controller ?? TextEditingController(text: initialValue);
   }
 
   @override
   Widget build(BuildContext context) {
     return TextFormField(
       key: fieldKey,
+      enabled: widget.enabled,
       validator: (val) => validate(val),
       onSaved: (val) => save(val),
-      enabled: widget.enabled,
       style: widget.style,
       focusNode: readOnly ? AlwaysDisabledFocusNode() : widget.focusNode,
       decoration: widget.decoration.copyWith(enabled: widget.enabled),

--- a/lib/src/fields/form_builder_touch_spin.dart
+++ b/lib/src/fields/form_builder_touch_spin.dart
@@ -5,8 +5,6 @@ import 'package:flutter_touch_spin/flutter_touch_spin.dart';
 import 'package:intl/intl.dart';
 
 class FormBuilderTouchSpin extends FormBuilderField<num> {
-  final InputDecoration decoration;
-  final ValueChanged onChanged;
   final num step;
   final num min;
   final num max;
@@ -27,18 +25,18 @@ class FormBuilderTouchSpin extends FormBuilderField<num> {
   FormBuilderTouchSpin({
     Key key,
     @required String attribute,
-    num initialValue,
-    List<FormFieldValidator<num>> validators = const [],
     bool readOnly = false,
     AutovalidateMode autovalidateMode,
     bool enabled = true,
-    this.decoration = const InputDecoration(),
+    num initialValue,
+    InputDecoration decoration = const InputDecoration(),
+    ValueChanged<num> onChanged,
+    FormFieldSetter<num> onSaved,
+    ValueTransformer<num> valueTransformer,
+    List<FormFieldValidator<num>> validators = const [],
     this.step,
     this.min = 1,
     this.max = 9999,
-    this.onChanged,
-    ValueTransformer valueTransformer,
-    FormFieldSetter<num> onSaved,
     this.iconSize = 24.0,
     this.displayFormat,
     this.subtractIcon = const Icon(Icons.remove),
@@ -50,9 +48,12 @@ class FormBuilderTouchSpin extends FormBuilderField<num> {
   }) : super(
           key: key,
           attribute: attribute,
+          readOnly: readOnly,
           autovalidateMode: autovalidateMode,
           enabled: enabled,
           initialValue: initialValue,
+          decoration: decoration,
+          onChanged: onChanged,
           onSaved: onSaved,
           valueTransformer: valueTransformer,
           validators: validators,
@@ -63,17 +64,17 @@ class FormBuilderTouchSpin extends FormBuilderField<num> {
 }
 
 class _FormBuilderTouchSpinState
-    extends FormBuilderFieldState<FormBuilderTouchSpin, num> {
+    extends FormBuilderFieldState<FormBuilderTouchSpin, num, num> {
   @override
   Widget build(BuildContext context) {
-    return FormField(
-      autovalidateMode: widget.autovalidateMode,
-      enabled: widget.enabled,
+    return FormField<num>(
       key: fieldKey,
+      enabled: widget.enabled,
       initialValue: initialValue,
+      autovalidateMode: widget.autovalidateMode,
       validator: (val) => validate(val),
       onSaved: (val) => save(val),
-      builder: (FormFieldState<dynamic> field) {
+      builder: (FormFieldState<num> field) {
         return InputDecorator(
           decoration: widget.decoration.copyWith(
             enabled: widget.enabled,

--- a/lib/src/form_builder_field_option.dart
+++ b/lib/src/form_builder_field_option.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 
-class FormBuilderFieldOption extends StatelessWidget {
+class FormBuilderFieldOption<T> extends StatelessWidget {
   @Deprecated('Use `child` instead. Will be removed in the next major version.')
   final String label;
   final Widget child;
-  final dynamic value;
+  final T value;
 
   const FormBuilderFieldOption({
     Key key,

--- a/lib/src/form_builder_validators.dart
+++ b/lib/src/form_builder_validators.dart
@@ -203,7 +203,7 @@ class FormBuilderValidators {
   /// Common validator method that tests [val] against [validators].  When a
   /// validation generates an error message, it it returned, otherwise null.
   static String validateValidators<T>(
-      T val, List<FormFieldValidator> validators) {
+      T val, List<FormFieldValidator<T>> validators) {
     for (var i = 0; i < validators.length; i++) {
       final validatorResult = validators[i](val);
       if (validatorResult != null) {

--- a/lib/src/widgets/grouped_checkbox.dart
+++ b/lib/src/widgets/grouped_checkbox.dart
@@ -3,7 +3,7 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 
 class GroupedCheckbox<T> extends StatefulWidget {
   /// A list of string that describes each checkbox. Each item must be distinct.
-  final List<FormBuilderFieldOption> options;
+  final List<FormBuilderFieldOption<T>> options;
 
   /// A list of string which specifies automatically checked checkboxes.
   /// Every element must match an item from itemList.
@@ -205,7 +205,7 @@ class GroupedCheckbox<T> extends StatefulWidget {
   });
 
   @override
-  _GroupedCheckboxState createState() => _GroupedCheckboxState();
+  _GroupedCheckboxState<T> createState() => _GroupedCheckboxState<T>();
 }
 
 class _GroupedCheckboxState<T> extends State<GroupedCheckbox<T>> {

--- a/lib/src/widgets/grouped_radio.dart
+++ b/lib/src/widgets/grouped_radio.dart
@@ -5,7 +5,7 @@ import 'grouped_checkbox.dart';
 
 class GroupedRadio<T> extends StatefulWidget {
   /// A list of string that describes each checkbox. Each item must be distinct.
-  final List<FormBuilderFieldOption> options;
+  final List<FormBuilderFieldOption<T>> options;
 
   /// A list of string which specifies automatically checked checkboxes.
   /// Every element must match an item from itemList.
@@ -197,7 +197,7 @@ class GroupedRadio<T> extends StatefulWidget {
   });
 
   @override
-  _GroupedRadioState createState() => _GroupedRadioState();
+  _GroupedRadioState<T> createState() => _GroupedRadioState<T>();
 }
 
 class _GroupedRadioState<T> extends State<GroupedRadio<T>> {
@@ -205,10 +205,10 @@ class _GroupedRadioState<T> extends State<GroupedRadio<T>> {
 
   @override
   void initState() {
+    super.initState();
     if (widget.value != null) {
       selectedValue = widget.value;
     }
-    super.initState();
   }
 
   @override


### PR DESCRIPTION
* Ensured that each field supports `enabled`, independent of `readOnly` since these are two separate ideas.
* Added `autovalidateMode` property across fields. 
* Saved hundreds of lines of code by avoiding copy/paste duplication across classes.
* Removed code that set `_readOnly` during `build()`. Resolves #511 
* Reviewed and improved type constraints, making the code more type safe.
