### PR TITLE
Form Field Validator

### DIFF
--- a/lib/src/form_builder_validators.dart
+++ b/lib/src/form_builder_validators.dart
@@ -244,25 +244,6 @@ class FormBuilderValidators {
     };
   }
 
-  // TODO(any): l10n
-  /// [FormFieldValidator] that requires the field's value to be a valid double.
-  static FormFieldValidator double_(
-    BuildContext context, {
-    String errorText,
-  }) {
-    return (valueCandidate) {
-      if (null != valueCandidate) {
-        assert(valueCandidate is String);
-        if (valueCandidate.isNotEmpty &&
-            double.tryParse(valueCandidate) == null) {
-          return errorText ??
-              FormBuilderLocalizations.of(context).numericErrorText;
-        }
-      }
-      return null;
-    };
-  }
-
   /// [FormFieldValidator] that requires the field's value to be a valid credit card number.
   static FormFieldValidator creditCard(
     BuildContext context, {

--- a/test/form_builder_validators_test.dart
+++ b/test/form_builder_validators_test.dart
@@ -151,6 +151,38 @@ void main() {
           }));
 
   testWidgets(
+      'FormBuilderValidators.integer',
+      (WidgetTester tester) => testValidations(tester, (context) {
+            final validator = FormBuilderValidators.integer(context);
+            // Pass
+            expect(validator(null), isNull);
+            expect(validator(''), isNull);
+            expect(validator('0'), isNull);
+            expect(validator('31'), isNull);
+            expect(validator('-1'), isNull);
+            // Fail
+            expect(validator('-1.01'), isNotNull);
+            expect(validator('1.'), isNotNull);
+            expect(validator('A'), isNotNull);
+            expect(validator('XYZ'), isNotNull);
+          }));
+
+  testWidgets(
+      'FormBuilderValidators.match',
+      (WidgetTester tester) => testValidations(tester, (context) {
+            final validator = FormBuilderValidators.match(context, '^A[0-9]\$');
+            // Pass
+            expect(validator(null), isNull);
+            expect(validator(''), isNull);
+            expect(validator('A1'), isNull);
+            expect(validator('A9'), isNull);
+            // Fail
+            expect(validator('A'), isNotNull);
+            expect(validator('Z9'), isNotNull);
+            expect(validator('A12'), isNotNull);
+          }));
+
+  testWidgets(
       'FormBuilderValidators.url',
       (WidgetTester tester) => testValidations(tester, (context) {
             final validator = FormBuilderValidators.url(context);


### PR DESCRIPTION
* Removed the `double_` validator because it is basically a duplicate of `numeric`.
* Added unit tests for `integer` and `match` validators.