### PR TITLE
Removed unnecessary after_init package.

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -8,13 +8,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "7.0.0"
-  after_init:
-    dependency: "direct main"
-    description:
-      name: after_init
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.2"
   analyzer:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  after_init: ^0.1.2
   community_material_icon: ^5.4.55
   # country_code_picker: ^1.6.2
   country_pickers: ^1.3.0


### PR DESCRIPTION
* Removed `after_init` package because it is not necessary.
* Minor efficiency improvement for `readOnly` and `initialValue`.
* Improved the lifecycle management of `_focusNode`, including proper disposal.
* Moved `dispose` so that you can see it right after `initState` because they need to balance each other out.