### PR TITLE
Revised value getter to not include initialValue.

### DIFF
--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -65,7 +65,7 @@ class FormBuilderState extends State<FormBuilder> {
 
   Map<String, dynamic> _value;
 
-  Map<String, dynamic> get value => {...widget.initialValue ?? {}, ..._value};
+  Map<String, dynamic> get value => Map.unmodifiable(_value);
 
   Map<String, dynamic> get initialValue => widget.initialValue;
 


### PR DESCRIPTION
Old implementation would risk excluding a new value, but still present the initial value, which is wrong.