### PR TITLE
Enabled strict-inference and enabled stricter type checks.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,3 +3,10 @@ include: package:pedantic/analysis_options.yaml
 analyzer:
   exclude:
     - lib/l10n/**
+
+  language:
+    strict-inference: true
+
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:pedantic/analysis_options.yaml

--- a/example/lib/sources/complete_form.dart
+++ b/example/lib/sources/complete_form.dart
@@ -14,7 +14,6 @@ class CompleteForm extends StatefulWidget {
 }
 
 class CompleteFormState extends State<CompleteForm> {
-  var data;
   bool autoValidate = true;
   bool readOnly = false;
   bool showSegmentedControl = true;
@@ -22,7 +21,7 @@ class CompleteFormState extends State<CompleteForm> {
   bool _ageHasError = false;
   bool _genderHasError = false;
 
-  final ValueChanged _onChanged = (val) => print(val);
+  final ValueChanged<dynamic> _onChanged = (dynamic val) => print(val);
   var genderOptions = ['Male', 'Female', 'Other'];
 
   @override
@@ -102,7 +101,7 @@ class CompleteFormState extends State<CompleteForm> {
                     colorPickerType: ColorPickerType.MaterialPicker,
                     decoration: const InputDecoration(labelText: 'Pick Color'),
                   ),
-                  FormBuilderChipsInput(
+                  FormBuilderChipsInput<Contact>(
                     decoration: const InputDecoration(labelText: 'Chips'),
                     name: 'chips_test',
                     onChanged: _onChanged,
@@ -258,7 +257,7 @@ class CompleteFormState extends State<CompleteForm> {
                     keyboardType: TextInputType.number,
                     textInputAction: TextInputAction.next,
                   ),
-                  FormBuilderDropdown(
+                  FormBuilderDropdown<String>(
                     // autovalidate: true,
                     name: 'gender',
                     decoration: InputDecoration(
@@ -286,7 +285,7 @@ class CompleteFormState extends State<CompleteForm> {
                       });
                     },
                   ),
-                  FormBuilderTypeAhead(
+                  FormBuilderTypeAhead<String>(
                     decoration: const InputDecoration(
                       labelText: 'Country',
                     ),
@@ -315,13 +314,13 @@ class CompleteFormState extends State<CompleteForm> {
                       }
                     },
                   ),
-                  FormBuilderRadioGroup(
+                  FormBuilderRadioGroup<String>(
                     decoration: const InputDecoration(
                       labelText: 'My chosen language',
                     ),
                     name: 'best_language',
                     onChanged: _onChanged,
-                    validator: FormBuilderValidators.compose(
+                    validator: FormBuilderValidators.compose<String>(
                         [FormBuilderValidators.required(context)]),
                     options: ['Dart', 'Kotlin', 'Java', 'Swift', 'Objective-C']
                         .map((lang) => FormBuilderFieldOption(
@@ -417,7 +416,7 @@ class CompleteFormState extends State<CompleteForm> {
                     ),
                     onChanged: _onChanged,
                     priorityListByIsoCode: ['KE'],
-                    validator: FormBuilderValidators.compose([
+                    validator: FormBuilderValidators.compose<String>([
                       FormBuilderValidators.numeric(context,
                           errorText: 'Invalid phone number'),
                       FormBuilderValidators.required(context,

--- a/example/lib/sources/complete_form.dart
+++ b/example/lib/sources/complete_form.dart
@@ -21,7 +21,7 @@ class CompleteFormState extends State<CompleteForm> {
   bool _ageHasError = false;
   bool _genderHasError = false;
 
-  final ValueChanged<dynamic> _onChanged = (dynamic val) => print(val);
+  final ValueChanged _onChanged = (val) => print(val);
   var genderOptions = ['Male', 'Female', 'Other'];
 
   @override

--- a/example/lib/sources/complete_form.dart
+++ b/example/lib/sources/complete_form.dart
@@ -320,7 +320,7 @@ class CompleteFormState extends State<CompleteForm> {
                     ),
                     name: 'best_language',
                     onChanged: _onChanged,
-                    validator: FormBuilderValidators.compose<String>(
+                    validator: FormBuilderValidators.compose(
                         [FormBuilderValidators.required(context)]),
                     options: ['Dart', 'Kotlin', 'Java', 'Swift', 'Objective-C']
                         .map((lang) => FormBuilderFieldOption(
@@ -416,7 +416,7 @@ class CompleteFormState extends State<CompleteForm> {
                     ),
                     onChanged: _onChanged,
                     priorityListByIsoCode: ['KE'],
-                    validator: FormBuilderValidators.compose<String>([
+                    validator: FormBuilderValidators.compose([
                       FormBuilderValidators.numeric(context,
                           errorText: 'Invalid phone number'),
                       FormBuilderValidators.required(context,

--- a/lib/localization/form_builder_localizations.dart
+++ b/lib/localization/form_builder_localizations.dart
@@ -38,7 +38,7 @@ class FormBuilderLocalizations {
     );
   }
 
-  String equalErrorText(dynamic value) => Intl.message(
+  String equalErrorText<T>(T value) => Intl.message(
         'This field value must be equal to $value.',
         name: 'equalErrorText',
         args: [value],

--- a/lib/localization/form_builder_localizations.dart
+++ b/lib/localization/form_builder_localizations.dart
@@ -38,35 +38,35 @@ class FormBuilderLocalizations {
     );
   }
 
-  String equalErrorText(value) => Intl.message(
+  String equalErrorText(dynamic value) => Intl.message(
         'This field value must be equal to $value.',
         name: 'equalErrorText',
         args: [value],
         desc: 'Error Text for equal validator',
       );
 
-  String minErrorText(min) => Intl.message(
+  String minErrorText(num min) => Intl.message(
         'Value must be greater than or equal to $min.',
         name: 'minErrorText',
         args: [min],
         desc: 'Error Text for required field',
       );
 
-  String minLengthErrorText(minLength) => Intl.message(
+  String minLengthErrorText(int minLength) => Intl.message(
         'Value must have a length greater than or equal to $minLength',
         name: 'minLengthErrorText',
         args: [minLength],
         desc: 'Error Text for minLength validator',
       );
 
-  String maxErrorText(max) => Intl.message(
+  String maxErrorText(num max) => Intl.message(
         'Value must be less than or equal to $max',
         name: 'maxErrorText',
         args: [max],
         desc: 'Error Text for max validator',
       );
 
-  String maxLengthErrorText(maxLength) => Intl.message(
+  String maxLengthErrorText(int maxLength) => Intl.message(
         'Value must have a length less than or equal to $maxLength',
         name: 'maxLengthErrorText',
         args: [maxLength],

--- a/lib/src/fields/form_builder_checkbox.dart
+++ b/lib/src/fields/form_builder_checkbox.dart
@@ -102,7 +102,7 @@ class FormBuilderCheckbox extends FormBuilderField<bool> {
           decoration: decoration,
           focusNode: focusNode,
           builder: (FormFieldState<bool> field) {
-            final _FormBuilderCheckboxState state = field;
+            final state = field as _FormBuilderCheckboxState;
 
             return InputDecorator(
               decoration: state.decoration(),

--- a/lib/src/fields/form_builder_checkbox_group.dart
+++ b/lib/src/fields/form_builder_checkbox_group.dart
@@ -28,7 +28,7 @@ class FormBuilderCheckboxGroup<T> extends FormBuilderField<List<T>> {
     Key key,
     //From Super
     @required String name,
-    FormFieldValidator validator,
+    FormFieldValidator<List<T>> validator,
     List<T> initialValue,
     InputDecoration decoration = const InputDecoration(),
     ValueChanged<List<T>> onChanged,
@@ -71,7 +71,7 @@ class FormBuilderCheckboxGroup<T> extends FormBuilderField<List<T>> {
           decoration: decoration,
           focusNode: focusNode,
           builder: (FormFieldState<List<T>> field) {
-            final _FormBuilderCheckboxGroupState<T> state = field;
+            final state = field as _FormBuilderCheckboxGroupState<T>;
 
             return InputDecorator(
               decoration: state.decoration(),

--- a/lib/src/fields/form_builder_chips_input.dart
+++ b/lib/src/fields/form_builder_chips_input.dart
@@ -67,7 +67,7 @@ class FormBuilderChipsInput<T> extends FormBuilderField<List<T>> {
           decoration: decoration,
           focusNode: focusNode,
           builder: (FormFieldState<List<T>> field) {
-            final _FormBuilderChipsInputState<T> state = field;
+            final state = field as _FormBuilderChipsInputState<T>;
 
             return ChipsInput<T>(
               key: ObjectKey(state.value),

--- a/lib/src/fields/form_builder_choice_chips.dart
+++ b/lib/src/fields/form_builder_choice_chips.dart
@@ -288,7 +288,7 @@ class FormBuilderChoiceChip<T> extends FormBuilderField<T> {
             decoration: decoration,
             focusNode: focusNode,
             builder: (FormFieldState<T> field) {
-              final _FormBuilderChoiceChipState<T> state = field;
+              final state = field as _FormBuilderChoiceChipState<T>;
 
               return InputDecorator(
                 decoration: state.decoration(),

--- a/lib/src/fields/form_builder_color_picker.dart
+++ b/lib/src/fields/form_builder_color_picker.dart
@@ -123,7 +123,7 @@ class FormBuilderColorPickerField extends FormBuilderField<Color> {
           onReset: onReset,
           decoration: decoration,
           builder: (FormFieldState<Color> field) {
-            final _FormBuilderColorPickerFieldState state = field;
+            final state = field as _FormBuilderColorPickerFieldState;
             return TextField(
               style: style,
               decoration: state.decoration().copyWith(

--- a/lib/src/fields/form_builder_date_range_picker.dart
+++ b/lib/src/fields/form_builder_date_range_picker.dart
@@ -128,7 +128,7 @@ class FormBuilderDateRangePicker extends FormBuilderField<List<DateTime>> {
           decoration: decoration,
           focusNode: focusNode,
           builder: (FormFieldState<List<DateTime>> field) {
-            final FormBuilderDateRangePickerState state = field;
+            final state = field as FormBuilderDateRangePickerState;
 
             return TextField(
               enabled: enabled,
@@ -258,7 +258,7 @@ class FormBuilderDateRangePickerState
   }
 
   @override
-  void didChange(value) {
+  void didChange(List<DateTime> value) {
     super.didChange(value);
     _setTextFieldString();
   }

--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -232,7 +232,7 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
           decoration: decoration,
           focusNode: focusNode,
           builder: (FormFieldState<DateTime> field) {
-            final _FormBuilderDateTimePickerState state = field;
+            final state = field as _FormBuilderDateTimePickerState;
 
             return DateTimeField(
               initialValue: state.initialValue,

--- a/lib/src/fields/form_builder_dropdown.dart
+++ b/lib/src/fields/form_builder_dropdown.dart
@@ -225,7 +225,7 @@ class FormBuilderDropdown<T> extends FormBuilderField<T> {
           onReset: onReset,
           decoration: decoration,
           builder: (FormFieldState<T> field) {
-            final _FormBuilderDropdownState<T> state = field;
+            final state = field as _FormBuilderDropdownState<T>;
             // DropdownButtonFormField
             // TextFormField
 
@@ -261,7 +261,7 @@ class FormBuilderDropdown<T> extends FormBuilderField<T> {
                         iconDisabledColor: iconDisabledColor,
                         iconEnabledColor: iconEnabledColor,
                         onChanged: enabled
-                            ? (value) => _changeValue<T>(field, value)
+                            ? (value) => _changeValue<T>(state, value)
                             : null,
                         onTap: onTap,
                         focusNode: state.effectiveFocusNode,

--- a/lib/src/fields/form_builder_file_picker.dart
+++ b/lib/src/fields/form_builder_file_picker.dart
@@ -32,7 +32,7 @@ class FormBuilderFilePicker extends FormBuilderField<List<PlatformFile>> {
   /// If you want to track picking status, for example, because some files may take some time to be
   /// cached (particularly those picked from cloud providers), you may want to set [onFileLoading] handler
   /// that will give you the current status of picking.
-  final Function(FilePickerStatus) onFileLoading;
+  final void Function(FilePickerStatus) onFileLoading;
 
   /// Whether to allow file compression
   final bool allowCompression;
@@ -78,7 +78,7 @@ class FormBuilderFilePicker extends FormBuilderField<List<PlatformFile>> {
           decoration: decoration,
           focusNode: focusNode,
           builder: (FormFieldState<List<PlatformFile>> field) {
-            final _FormBuilderFilePickerState state = field;
+            final state = field as _FormBuilderFilePickerState;
 
             return InputDecorator(
               decoration: state.decoration(),

--- a/lib/src/fields/form_builder_filter_chips.dart
+++ b/lib/src/fields/form_builder_filter_chips.dart
@@ -88,7 +88,7 @@ class FormBuilderFilterChip<T> extends FormBuilderField<List<T>> {
           decoration: decoration,
           focusNode: focusNode,
           builder: (FormFieldState<List<T>> field) {
-            final _FormBuilderFilterChipState<T> state = field;
+            final state = field as _FormBuilderFilterChipState<T>;
             return InputDecorator(
               decoration: state.decoration(),
               child: Wrap(

--- a/lib/src/fields/form_builder_location_field.dart
+++ b/lib/src/fields/form_builder_location_field.dart
@@ -168,11 +168,11 @@ class FormBuilderLocationField extends FormBuilderField<CameraPosition> {
     Key key,
     //From Super
     @required String name,
-    FormFieldValidator validator,
+    FormFieldValidator<CameraPosition> validator,
     CameraPosition initialValue,
     InputDecoration decoration = const InputDecoration(),
     ValueChanged<CameraPosition> onChanged,
-    ValueTransformer valueTransformer,
+    ValueTransformer<CameraPosition> valueTransformer,
     bool enabled = true,
     FormFieldSetter onSaved,
     AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
@@ -226,7 +226,7 @@ class FormBuilderLocationField extends FormBuilderField<CameraPosition> {
           onReset: onReset,
           decoration: decoration,
           builder: (FormFieldState<CameraPosition> field) {
-            final _FormBuilderLocationFieldState state = field;
+            final state = field as _FormBuilderLocationFieldState;
 
             return Row(
               crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/src/fields/form_builder_phone_field.dart
+++ b/lib/src/fields/form_builder_phone_field.dart
@@ -56,7 +56,7 @@ class FormBuilderPhoneField extends FormBuilderField<String> {
     Key key,
     //From Super
     @required String name,
-    FormFieldValidator validator,
+    FormFieldValidator<String> validator,
     String initialValue,
     InputDecoration decoration = const InputDecoration(),
     ValueChanged<String> onChanged,
@@ -121,7 +121,7 @@ class FormBuilderPhoneField extends FormBuilderField<String> {
           onReset: onReset,
           decoration: decoration,
           builder: (FormFieldState<String> field) {
-            final _FormBuilderPhoneFieldState state = field;
+            final state = field as _FormBuilderPhoneFieldState;
 
             return InputDecorator(
               decoration: state.decoration(),
@@ -296,7 +296,7 @@ class _FormBuilderPhoneFieldState
   }
 
   void _openCountryPickerDialog() {
-    showDialog(
+    showDialog<void>(
       context: context,
       builder: (context) {
         return Theme(

--- a/lib/src/fields/form_builder_radio_group.dart
+++ b/lib/src/fields/form_builder_radio_group.dart
@@ -68,7 +68,7 @@ class FormBuilderRadioGroup<T> extends FormBuilderField<T> {
           focusNode: focusNode,
           decoration: decoration,
           builder: (FormFieldState<T> field) {
-            final _FormBuilderRadioGroupState<T> state = field;
+            final state = field as _FormBuilderRadioGroupState<T>;
 
             return InputDecorator(
               decoration: state.decoration(),

--- a/lib/src/fields/form_builder_range_slider.dart
+++ b/lib/src/fields/form_builder_range_slider.dart
@@ -144,7 +144,7 @@ class FormBuilderRangeSlider extends FormBuilderField<RangeValues> {
             onReset: onReset,
             decoration: decoration,
             builder: (FormFieldState<RangeValues> field) {
-              final _FormBuilderRangeSliderState state = field;
+              final state = field as _FormBuilderRangeSliderState;
               final _numberFormat = numberFormat ?? NumberFormat.compact();
 
               return InputDecorator(

--- a/lib/src/fields/form_builder_rating.dart
+++ b/lib/src/fields/form_builder_rating.dart
@@ -68,7 +68,7 @@ class FormBuilderRating extends FormBuilderField<double> {
           onReset: onReset,
           decoration: decoration,
           builder: (FormFieldState<double> field) {
-            final _FormBuilderRateState state = field;
+            final state = field as _FormBuilderRateState;
             final widget = state.widget;
 
             return InputDecorator(

--- a/lib/src/fields/form_builder_searchable_dropdown.dart
+++ b/lib/src/fields/form_builder_searchable_dropdown.dart
@@ -157,7 +157,7 @@ class FormBuilderSearchableDropdown<T> extends FormBuilderField<T> {
           onReset: onReset,
           decoration: decoration,
           builder: (FormFieldState<T> field) {
-            final _FormBuilderSearchableDropdownState<T> state = field;
+            final state = field as _FormBuilderSearchableDropdownState<T>;
 
             return InputDecorator(
               decoration: state.decoration(),

--- a/lib/src/fields/form_builder_segmented_control.dart
+++ b/lib/src/fields/form_builder_segmented_control.dart
@@ -68,7 +68,7 @@ class FormBuilderSegmentedControl<T> extends FormBuilderField<T> {
           onReset: onReset,
           decoration: decoration,
           builder: (FormFieldState<T> field) {
-            final _FormBuilderSegmentedControlState<T> state = field;
+            final state = field as _FormBuilderSegmentedControlState<T>;
             final theme = Theme.of(state.context);
 
             return InputDecorator(

--- a/lib/src/fields/form_builder_signature_pad.dart
+++ b/lib/src/fields/form_builder_signature_pad.dart
@@ -59,7 +59,7 @@ class FormBuilderSignaturePad extends FormBuilderField<Uint8List> {
           onReset: onReset,
           decoration: decoration,
           builder: (FormFieldState<Uint8List> field) {
-            final _FormBuilderSignaturePadState state = field;
+            final state = field as _FormBuilderSignaturePadState;
             final theme = Theme.of(state.context);
             final localizations = MaterialLocalizations.of(state.context);
 

--- a/lib/src/fields/form_builder_slider.dart
+++ b/lib/src/fields/form_builder_slider.dart
@@ -170,7 +170,7 @@ class FormBuilderSlider extends FormBuilderField<double> {
           onReset: onReset,
           decoration: decoration,
           builder: (FormFieldState<double> field) {
-            final _FormBuilderSliderState state = field;
+            final state = field as _FormBuilderSliderState;
             final _numberFormat = numberFormat ?? NumberFormat.compact();
             return InputDecorator(
               decoration: state.decoration(),

--- a/lib/src/fields/form_builder_switch.dart
+++ b/lib/src/fields/form_builder_switch.dart
@@ -120,7 +120,7 @@ class FormBuilderSwitch extends FormBuilderField<bool> {
           onReset: onReset,
           decoration: decoration,
           builder: (FormFieldState<bool> field) {
-            final _FormBuilderSwitchState state = field;
+            final state = field as _FormBuilderSwitchState;
 
             return InputDecorator(
               decoration: state.decoration(),

--- a/lib/src/fields/form_builder_text_field.dart
+++ b/lib/src/fields/form_builder_text_field.dart
@@ -384,7 +384,7 @@ class FormBuilderTextField extends FormBuilderField<String> {
           decoration: decoration,
           focusNode: focusNode,
           builder: (FormFieldState<String> field) {
-            final _FormBuilderTextFieldState state = field;
+            final state = field as _FormBuilderTextFieldState;
             /*final effectiveDecoration = (decoration ?? const InputDecoration())
                 .applyDefaults(Theme.of(field.context).inputDecorationTheme);*/
             void onChangedHandler(String value) {

--- a/lib/src/fields/form_builder_touch_spin.dart
+++ b/lib/src/fields/form_builder_touch_spin.dart
@@ -4,19 +4,19 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_touch_spin/flutter_touch_spin.dart';
 import 'package:intl/intl.dart';
 
-class FormBuilderTouchSpin extends FormBuilderField<double> {
+class FormBuilderTouchSpin extends FormBuilderField<num> {
   /// Value to increment or decrement by
-  final double step;
+  final num step;
 
   /// The minimum value the user can select.
   ///
   /// Defaults to 0.0. Must be less than or equal to [max].
-  final double min;
+  final num min;
 
   /// The maximum value the user can select.
   ///
   /// Defaults to 1.0. Must be greater than or equal to [min].
-  final double max;
+  final num max;
 
   /// Icon for the decrement button
   final Icon subtractIcon;
@@ -46,13 +46,13 @@ class FormBuilderTouchSpin extends FormBuilderField<double> {
     Key key,
     //From Super
     @required String name,
-    FormFieldValidator<double> validator,
-    @required double initialValue,
+    FormFieldValidator<num> validator,
+    @required num initialValue,
     InputDecoration decoration = const InputDecoration(),
-    ValueChanged<double> onChanged,
-    ValueTransformer<double> valueTransformer,
+    ValueChanged<num> onChanged,
+    ValueTransformer<num> valueTransformer,
     bool enabled = true,
-    FormFieldSetter<double> onSaved,
+    FormFieldSetter<num> onSaved,
     AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
     VoidCallback onReset,
     FocusNode focusNode,
@@ -80,8 +80,8 @@ class FormBuilderTouchSpin extends FormBuilderField<double> {
           onReset: onReset,
           decoration: decoration,
           focusNode: focusNode,
-          builder: (FormFieldState<double> field) {
-            final _FormBuilderTouchSpinState state = field;
+          builder: (FormFieldState<num> field) {
+            final state = field as _FormBuilderTouchSpinState;
             final theme = Theme.of(state.context);
 
             return InputDecorator(
@@ -117,4 +117,4 @@ class FormBuilderTouchSpin extends FormBuilderField<double> {
 }
 
 class _FormBuilderTouchSpinState
-    extends FormBuilderFieldState<FormBuilderTouchSpin, double> {}
+    extends FormBuilderFieldState<FormBuilderTouchSpin, num> {}

--- a/lib/src/fields/form_builder_typeahead.dart
+++ b/lib/src/fields/form_builder_typeahead.dart
@@ -180,7 +180,7 @@ class FormBuilderTypeAhead<T> extends FormBuilderField<T> {
 
   /// The configuration of the [TextField](https://docs.flutter.io/flutter/material/TextField-class.html)
   /// that the TypeAhead widget displays
-  final TextFieldConfiguration textFieldConfiguration;
+  final TextFieldConfiguration<T> textFieldConfiguration;
 
   /// How far below the text field should the suggestions box be
   ///
@@ -309,7 +309,7 @@ class FormBuilderTypeAhead<T> extends FormBuilderField<T> {
           onReset: onReset,
           decoration: decoration,
           builder: (FormFieldState<T> field) {
-            final _FormBuilderTypeAheadState<T> state = field;
+            final state = field as _FormBuilderTypeAheadState<T>;
             final theme = Theme.of(state.context);
 
             return TypeAheadField<T>(
@@ -323,7 +323,8 @@ class FormBuilderTypeAhead<T> extends FormBuilderField<T> {
                       ),
                 focusNode: state.effectiveFocusNode,
                 decoration: state.decoration(),
-              ),
+              ) as TextFieldConfiguration<
+                  dynamic>, // HACK to satisfy strictness
               suggestionsCallback: suggestionsCallback,
               itemBuilder: itemBuilder,
               transitionBuilder: (context, suggestionsBox, controller) =>

--- a/lib/src/form_builder.dart
+++ b/lib/src/form_builder.dart
@@ -57,7 +57,7 @@ class FormBuilder extends StatefulWidget {
     this.onChanged,
     this.autovalidateMode,
     this.onWillPop,
-    this.initialValue = const {},
+    this.initialValue = const <String, dynamic>{},
     this.skipDisabled = false,
   }) : super(key: key);
 
@@ -75,7 +75,7 @@ class FormBuilderState extends State<FormBuilder> {
 
   Map<String, dynamic> _value;
 
-  Map<String, dynamic> get value => Map.unmodifiable(_value);
+  Map<String, dynamic> get value => Map<String, dynamic>.unmodifiable(_value);
 
   Map<String, dynamic> get initialValue => widget.initialValue;
 
@@ -85,7 +85,7 @@ class FormBuilderState extends State<FormBuilder> {
   void initState() {
     super.initState();
     _fields = {};
-    _value = {};
+    _value = <String, dynamic>{};
   }
 
   @override
@@ -96,13 +96,13 @@ class FormBuilderState extends State<FormBuilder> {
 
   void setInternalFieldValue(String name, dynamic value) {
     setState(() {
-      _value = {..._value, name: value};
+      _value = <String, dynamic>{..._value, name: value};
     });
   }
 
   void removeInternalFieldValue(String name) {
     setState(() {
-      _value = {..._value..remove(name)};
+      _value = <String, dynamic>{..._value..remove(name)};
     });
   }
 
@@ -134,7 +134,7 @@ class FormBuilderState extends State<FormBuilder> {
   }
 
   void patchValue(Map<String, dynamic> val) {
-    val.forEach((key, value) {
+    val.forEach((key, dynamic value) {
       _fields[key]?.patchValue(value);
     });
   }

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -75,7 +75,7 @@ abstract class FormBuilderField<T> extends FormField<T> {
 abstract class FormBuilderFieldState<F extends FormBuilderField<T>, T>
     extends FormFieldState<T> {
   @override
-  F get widget => super.widget;
+  F get widget => super.widget as F;
 
   FormBuilderState get formState => _formBuilderState;
 
@@ -84,7 +84,8 @@ abstract class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   /// initialValue prevails.
   T get initialValue =>
       widget.initialValue ??
-      (_formBuilderState?.initialValue ?? const {})[widget.name];
+      (_formBuilderState?.initialValue ??
+          const <String, dynamic>{})[widget.name] as T;
 
   FormBuilderState _formBuilderState;
 

--- a/lib/src/form_builder_validators.dart
+++ b/lib/src/form_builder_validators.dart
@@ -20,16 +20,15 @@ class FormBuilderValidators {
   }
 
   /// [FormFieldValidator] that requires the field have a non-empty value.
-  static FormFieldValidator required(
+  static FormFieldValidator<T> required<T>(
     BuildContext context, {
     String errorText,
   }) {
-    return (dynamic valueCandidate) {
+    return (T valueCandidate) {
       if (valueCandidate == null ||
-          ((valueCandidate is String ||
-                  valueCandidate is Iterable ||
-                  valueCandidate is Map) &&
-              valueCandidate.isEmpty as bool)) {
+          (valueCandidate is String && valueCandidate.isEmpty) ||
+          (valueCandidate is Iterable && valueCandidate.isEmpty) ||
+          (valueCandidate is Map && valueCandidate.isEmpty)) {
         return errorText ??
             FormBuilderLocalizations.of(context).requiredErrorText;
       }
@@ -52,13 +51,13 @@ class FormBuilderValidators {
   // TODO(any): implement inclusive in l10n
   /// [FormFieldValidator] that requires the field's value to be greater than
   /// (or equal) to the provided number.
-  static FormFieldValidator min(
+  static FormFieldValidator<T> min<T>(
     BuildContext context,
     num min, {
     bool inclusive = true,
     String errorText,
   }) {
-    return (dynamic valueCandidate) {
+    return (T valueCandidate) {
       if (valueCandidate != null) {
         assert(valueCandidate is num || valueCandidate is String);
         final number = valueCandidate is num
@@ -77,13 +76,13 @@ class FormBuilderValidators {
   // TODO(any): implement inclusive in l10n
   /// [FormFieldValidator] that requires the field's value to be less than
   /// (or equal) to the provided number.
-  static FormFieldValidator max(
+  static FormFieldValidator<T> max<T>(
     BuildContext context,
     num max, {
     bool inclusive = true,
     String errorText,
   }) {
-    return (dynamic valueCandidate) {
+    return (T valueCandidate) {
       if (valueCandidate != null) {
         assert(valueCandidate is num || valueCandidate is String);
         final number = valueCandidate is num

--- a/lib/src/form_builder_validators.dart
+++ b/lib/src/form_builder_validators.dart
@@ -24,12 +24,12 @@ class FormBuilderValidators {
     BuildContext context, {
     String errorText,
   }) {
-    return (valueCandidate) {
+    return (dynamic valueCandidate) {
       if (valueCandidate == null ||
           ((valueCandidate is String ||
                   valueCandidate is Iterable ||
                   valueCandidate is Map) &&
-              valueCandidate.isEmpty)) {
+              valueCandidate.isEmpty as bool)) {
         return errorText ??
             FormBuilderLocalizations.of(context).requiredErrorText;
       }
@@ -58,7 +58,7 @@ class FormBuilderValidators {
     bool inclusive = true,
     String errorText,
   }) {
-    return (valueCandidate) {
+    return (dynamic valueCandidate) {
       if (valueCandidate != null) {
         assert(valueCandidate is num || valueCandidate is String);
         final number = valueCandidate is num
@@ -83,7 +83,7 @@ class FormBuilderValidators {
     bool inclusive = true,
     String errorText,
   }) {
-    return (valueCandidate) {
+    return (dynamic valueCandidate) {
       if (valueCandidate != null) {
         assert(valueCandidate is num || valueCandidate is String);
         final number = valueCandidate is num
@@ -103,7 +103,7 @@ class FormBuilderValidators {
   /// greater than or equal to the provided minimum length.
   static FormFieldValidator<String> minLength(
     BuildContext context,
-    num minLength, {
+    int minLength, {
     bool allowEmpty = false,
     String errorText,
   }) {
@@ -121,7 +121,7 @@ class FormBuilderValidators {
   /// less than or equal to the provided maximum length.
   static FormFieldValidator<String> maxLength(
     BuildContext context,
-    num maxLength, {
+    int maxLength, {
     String errorText,
   }) {
     assert(maxLength > 0);
@@ -167,7 +167,7 @@ class FormBuilderValidators {
   /// [FormFieldValidator] that requires the field's value to match the provided regex pattern.
   static FormFieldValidator<String> match(
     BuildContext context,
-    Pattern pattern, {
+    String pattern, {
     String errorText,
   }) =>
       (valueCandidate) => true == valueCandidate?.isNotEmpty &&

--- a/lib/src/widgets/image_source_sheet.dart
+++ b/lib/src/widgets/image_source_sheet.dart
@@ -26,13 +26,13 @@ class ImageSourceBottomSheet extends StatefulWidget {
   /// Callback when an image is selected.
   ///
   /// **Note**: This will work on web platform whereas [onImageSelected] will not.
-  final Function(Uint8List) onImage;
+  final void Function(Uint8List) onImage;
 
   /// Callback when an image is selected.
   ///
   /// **Warning**: This will _NOT_ work on web platform because [File] is not
   /// available.
-  final Function(File) onImageSelected;
+  final void Function(File) onImageSelected;
 
   final Widget cameraIcon;
   final Widget galleryIcon;

--- a/test/form_builder_validators_test.dart
+++ b/test/form_builder_validators_test.dart
@@ -31,17 +31,53 @@ void main() {
   testWidgets(
       'FormBuilderValidators.required',
       (WidgetTester tester) => testValidations(tester, (context) {
-            final validator = FormBuilderValidators.required(context);
+            final validatorBool = FormBuilderValidators.required<bool>(context);
             // Pass
-            expect(validator(false), isNull);
-            expect(validator(0), isNull);
-            expect(validator('0'), isNull);
-            expect(validator('something long'), isNull);
-            expect(validator(DateTime.now()), isNull);
+            expect(validatorBool(false), isNull);
+            expect(validatorBool(true), isNull);
             // Fail
-            expect(validator(null), isNotNull);
-            expect(validator(''), isNotNull);
-            expect(validator(<dynamic>[]), isNotNull);
+            expect(validatorBool(null), isNotNull);
+
+            final validatorDate =
+                FormBuilderValidators.required<DateTime>(context);
+            // Pass
+            expect(validatorDate(DateTime.now()), isNull);
+            // Fail
+            expect(validatorDate(null), isNotNull);
+
+            final validatorInt = FormBuilderValidators.required<int>(context);
+            // Pass
+            expect(validatorInt(0), isNull);
+            // Fail
+            expect(validatorInt(null), isNotNull);
+
+            final validatorDouble =
+                FormBuilderValidators.required<double>(context);
+            // Pass
+            expect(validatorDouble(0), isNull);
+            expect(validatorDouble(0.1), isNull);
+            expect(validatorDouble(1.234), isNull);
+            expect(validatorDouble(-4.567), isNull);
+            // Fail
+            expect(validatorDouble(null), isNotNull);
+
+            final validatorString =
+                FormBuilderValidators.required<String>(context);
+            // Pass
+            expect(validatorString('0'), isNull);
+            expect(validatorString('something long'), isNull);
+            // Fail
+            expect(validatorString(null), isNotNull);
+            expect(validatorString(''), isNotNull);
+
+            final validatorList =
+                FormBuilderValidators.required<List<int>>(context);
+            // Pass
+            expect(validatorList(const [1]), isNull);
+            expect(validatorList(const [1, 2]), isNull);
+            // Fail
+            expect(validatorList(null), isNotNull);
+            expect(validatorList(const []), isNotNull);
           }));
 
   testWidgets(
@@ -108,41 +144,76 @@ void main() {
   testWidgets(
       'FormBuilderValidators.max',
       (WidgetTester tester) => testValidations(tester, (context) {
-            final validator = FormBuilderValidators.max(context, 20);
+            final validatorInt = FormBuilderValidators.max<int>(context, 20);
             // Pass
-            expect(validator(null), isNull);
-            expect(validator(''), isNull);
-            expect(validator(0), isNull);
-            expect(validator(-1), isNull);
-            expect(validator(-1.1), isNull);
-            expect(validator(1.2), isNull);
-            expect(validator('19'), isNull);
-            expect(validator('20'), isNull);
-            expect(validator(20), isNull);
+            expect(validatorInt(null), isNull);
+            expect(validatorInt(0), isNull);
+            expect(validatorInt(-1), isNull);
+            expect(validatorInt(20), isNull);
             // Fail
-            expect(validator(20.01), isNotNull);
-            expect(validator(21), isNotNull);
-            expect(validator('21'), isNotNull);
-            expect(validator(999), isNotNull);
+            expect(validatorInt(21), isNotNull);
+            expect(validatorInt(999), isNotNull);
+
+            final validatorDouble =
+                FormBuilderValidators.max<double>(context, 20);
+            // Pass
+            expect(validatorDouble(null), isNull);
+            expect(validatorDouble(0), isNull);
+            expect(validatorDouble(-1), isNull);
+            expect(validatorDouble(-1.1), isNull);
+            expect(validatorDouble(1.2), isNull);
+            expect(validatorDouble(20), isNull);
+            // Fail
+            expect(validatorDouble(20.01), isNotNull);
+            expect(validatorDouble(21), isNotNull);
+            expect(validatorDouble(999), isNotNull);
+
+            final validatorString =
+                FormBuilderValidators.max<String>(context, 20);
+            // Pass
+            expect(validatorString(null), isNull);
+            expect(validatorString(''), isNull);
+            expect(validatorString('19'), isNull);
+            expect(validatorString('20'), isNull);
+            // Fail
+            expect(validatorString('21'), isNotNull);
           }));
 
   testWidgets(
       'FormBuilderValidators.min',
       (WidgetTester tester) => testValidations(tester, (context) {
-            final validator = FormBuilderValidators.min(context, 30);
+            final validatorInt = FormBuilderValidators.min<int>(context, 30);
             // Pass
-            expect(validator(null), isNull);
-            expect(validator(''), isNull);
-            expect(validator(30.01), isNull);
-            expect(validator(31), isNull);
-            expect(validator('31'), isNull);
-            expect(validator(70), isNull);
+            expect(validatorInt(null), isNull);
+            expect(validatorInt(31), isNull);
+            expect(validatorInt(70), isNull);
             // Fail
-            expect(validator(-1), isNotNull);
-            expect(validator(0), isNotNull);
-            expect(validator('10'), isNotNull);
-            expect(validator(10), isNotNull);
-            expect(validator(29), isNotNull);
+            expect(validatorInt(-1), isNotNull);
+            expect(validatorInt(0), isNotNull);
+            expect(validatorInt(10), isNotNull);
+            expect(validatorInt(29), isNotNull);
+
+            final validatorDouble =
+                FormBuilderValidators.min<double>(context, 30);
+            // Pass
+            expect(validatorDouble(null), isNull);
+            expect(validatorDouble(30.01), isNull);
+            expect(validatorDouble(31), isNull);
+            expect(validatorDouble(70), isNull);
+            // Fail
+            expect(validatorDouble(-1), isNotNull);
+            expect(validatorDouble(0), isNotNull);
+            expect(validatorDouble(10), isNotNull);
+            expect(validatorDouble(29), isNotNull);
+
+            final validatorString =
+                FormBuilderValidators.min<String>(context, 30);
+            // Pass
+            expect(validatorString(null), isNull);
+            expect(validatorString(''), isNull);
+            expect(validatorString('31'), isNull);
+            // Fail
+            expect(validatorString('10'), isNotNull);
           }));
 
   testWidgets(

--- a/test/form_builder_validators_test.dart
+++ b/test/form_builder_validators_test.dart
@@ -41,7 +41,7 @@ void main() {
             // Fail
             expect(validator(null), isNotNull);
             expect(validator(''), isNotNull);
-            expect(validator([]), isNotNull);
+            expect(validator(<dynamic>[]), isNotNull);
           }));
 
   testWidgets(


### PR DESCRIPTION
* [Enabled strict inference](https://github.com/dart-lang/language/blob/master/resources/type-system/strict-inference.md#enabling-strict-inference) to identify type issues during static analysis (compile-time) rather than at runtime
* [Enabled stricter type checks](https://dart.dev/guides/language/analysis-options#enabling-additional-type-checks) that highlight `dynamic` to identify opportunities to apply stronger type checking
* Strictness does not apply to `example` code; it applies `pedantic` rules, but otherwise consistent with typical usage
* Added missing parameter types to `FormBuilderLocalizations` methods
* Added missing type declarations to a few parameterized type declarations
* Added missing return types for some Function variables
* Revised value type of `FormBuilderTouchSpin` to match underlying `TouchSpin`