### PR TITLE
Date time picker 548

### DIFF
--- a/example/lib/sources/complete_form.dart
+++ b/example/lib/sources/complete_form.dart
@@ -159,6 +159,18 @@ class CompleteFormState extends State<CompleteForm> {
                     ),
                     initialTime: TimeOfDay(hour: 8, minute: 0),
                     pickerType: PickerType.cupertino,
+                    //locale: Locale.fromSubtags(languageCode: 'fr'),
+                  ),
+                  FormBuilderDateTimePicker(
+                    name: 'date_es',
+                    initialValue: DateTime.now(),
+                    inputType: InputType.both,
+                    decoration: const InputDecoration(
+                      labelText: 'Hora de la cita',
+                    ),
+                    initialTime: TimeOfDay(hour: 8, minute: 0),
+                    pickerType: PickerType.cupertino,
+                    locale: Locale.fromSubtags(languageCode: 'es'),
                   ),
                   FormBuilderDateRangePicker(
                     name: 'date_range',

--- a/lib/src/fields/form_builder_date_range_picker.dart
+++ b/lib/src/fields/form_builder_date_range_picker.dart
@@ -190,10 +190,10 @@ class FormBuilderDateRangePickerState
 
   @override
   void initState() {
+    super.initState();
     _effectiveController =
         widget.controller ?? TextEditingController(text: _valueToText());
     effectiveFocusNode.addListener(_handleFocus);
-    super.initState();
   }
 
   @override

--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -345,12 +345,11 @@ class _FormBuilderDateTimePickerState
     DateTime newValue;
     switch (widget.inputType) {
       case InputType.date:
-        newValue = await _showDatePicker(context, currentValue) ?? currentValue;
+        newValue = await _showDatePicker(context, currentValue);
         break;
       case InputType.time:
         final newTime = await _showTimePicker(context, currentValue);
-        newValue =
-            newTime != null ? DateTimeField.convert(newTime) : currentValue;
+        newValue = null != newTime ? DateTimeField.convert(newTime) : null;
         break;
       case InputType.both:
         final date = await _showDatePicker(context, currentValue);
@@ -443,7 +442,7 @@ class _FormBuilderDateTimePickerState
         final newDateTime = timePickerResult ?? currentValue;
         return null != newDateTime ? TimeOfDay.fromDateTime(newDateTime) : null;
       }
-      final timePicker = showTimePicker(
+      final timePickerResult = await showTimePicker(
         context: context,
         initialTime: currentValue != null
             ? TimeOfDay.fromDateTime(currentValue)
@@ -452,7 +451,8 @@ class _FormBuilderDateTimePickerState
             (BuildContext context, Widget child) {
               return MediaQuery(
                 data: MediaQuery.of(context).copyWith(
-                    alwaysUse24HourFormat: widget.alwaysUse24HourFormat),
+                  alwaysUse24HourFormat: widget.alwaysUse24HourFormat,
+                ),
                 child: child,
               );
             },
@@ -463,7 +463,6 @@ class _FormBuilderDateTimePickerState
         confirmText: widget.confirmText,
         cancelText: widget.cancelText,
       );
-      final timePickerResult = await timePicker;
       return timePickerResult ??
           (currentValue != null ? TimeOfDay.fromDateTime(currentValue) : null);
     }

--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -236,7 +236,7 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
 
             return DateTimeField(
               initialValue: state.initialValue,
-              format: state.dateFormat,
+              format: state._dateFormat,
               validator: validator,
               onShowPicker: state.onShowPicker,
               autovalidate: autovalidateMode != AutovalidateMode.disabled &&
@@ -273,6 +273,7 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
               strutStyle: strutStyle,
               textCapitalization: textCapitalization,
               textInputAction: textInputAction,
+              onChanged: (val) => state.didChange(val),
             );
           },
         );
@@ -288,17 +289,16 @@ class _FormBuilderDateTimePickerState
     extends FormBuilderFieldState<FormBuilderDateTimePicker, DateTime> {
   TextEditingController _textFieldController;
 
-  // DateTime stateCurrentValue;
-
-  DateFormat get dateFormat => widget.format ?? _getDefaultDateTimeFormat();
+  DateFormat _dateFormat;
 
   @override
   void initState() {
     super.initState();
     _textFieldController = widget.controller ?? TextEditingController();
+    _dateFormat = widget.format ?? _getDefaultDateTimeFormat();
     final initVal = initialValue;
     _textFieldController.text =
-        initVal == null ? '' : dateFormat.format(initVal);
+        initVal == null ? '' : _dateFormat.format(initVal);
   }
 
   @override
@@ -318,25 +318,24 @@ class _FormBuilderDateTimePickerState
   }*/
 
   DateFormat _getDefaultDateTimeFormat() {
-    final appLocale = widget.locale ?? Localizations.localeOf(context);
-    final appLocaleCode = appLocale.toString();
+    final languageCode = widget.locale?.languageCode;
     switch (widget.inputType) {
       case InputType.time:
-        return DateFormat.Hm(appLocaleCode);
+        return DateFormat.Hm(languageCode);
       case InputType.date:
-        return DateFormat.yMd(appLocaleCode);
+        return DateFormat.yMd(languageCode);
       case InputType.both:
       default:
-        return DateFormat.yMd(appLocaleCode).add_Hms();
+        return DateFormat.yMd(languageCode).add_Hms();
     }
   }
 
   LocaleType _localeType() {
-    final locale = widget.locale ?? Localizations.localeOf(context);
-    final languageCode = locale.languageCode;
+    final shortLocaleCode = widget.locale?.languageCode ??
+        Intl.shortLocale(Intl.getCurrentLocale());
     return LocaleType.values.firstWhere(
-      (_) => languageCode == describeEnum(_),
-      orElse: () => null,
+      (_) => shortLocaleCode == describeEnum(_),
+      orElse: () => LocaleType.en,
     );
   }
 
@@ -421,36 +420,30 @@ class _FormBuilderDateTimePickerState
   }
 
   Future<TimeOfDay> _showTimePicker(
-      BuildContext context, DateTime currentValue) {
+      BuildContext context, DateTime currentValue) async {
     if (widget.timePicker != null) {
       return widget.timePicker(context);
     } else {
       if (widget.pickerType == PickerType.cupertino) {
-        if (widget.alwaysUse24HourFormat) {
-          return DatePicker.showTimePicker(
-            context,
-            showTitleActions: true,
-            currentTime: currentValue,
-            showSecondsColumn: false,
-            locale: _localeType(),
-          ).then(
-            (result) {
-              return TimeOfDay.fromDateTime(result ?? currentValue);
-            },
-          );
-        }
-        return DatePicker.showTime12hPicker(
-          context,
-          showTitleActions: true,
-          currentTime: currentValue,
-          locale: _localeType(),
-        ).then(
-          (result) {
-            return TimeOfDay.fromDateTime(result ?? currentValue);
-          },
-        );
+        final timePicker = widget.alwaysUse24HourFormat
+            ? DatePicker.showTimePicker(
+                context,
+                showTitleActions: true,
+                currentTime: currentValue,
+                showSecondsColumn: false,
+                locale: _localeType(),
+              )
+            : DatePicker.showTime12hPicker(
+                context,
+                showTitleActions: true,
+                currentTime: currentValue,
+                locale: _localeType(),
+              );
+        final timePickerResult = await timePicker;
+        final newDateTime = timePickerResult ?? currentValue;
+        return null != newDateTime ? TimeOfDay.fromDateTime(newDateTime) : null;
       }
-      return showTimePicker(
+      final timePicker = showTimePicker(
         context: context,
         initialTime: currentValue != null
             ? TimeOfDay.fromDateTime(currentValue)
@@ -469,20 +462,16 @@ class _FormBuilderDateTimePickerState
         helpText: widget.helpText,
         confirmText: widget.confirmText,
         cancelText: widget.cancelText,
-      ).then(
-        (result) {
-          return result ??
-              (currentValue != null
-                  ? TimeOfDay.fromDateTime(currentValue)
-                  : null);
-        },
       );
+      final timePickerResult = await timePicker;
+      return timePickerResult ??
+          (currentValue != null ? TimeOfDay.fromDateTime(currentValue) : null);
     }
   }
 
   @override
-  void patchValue(DateTime val) {
-    super.patchValue(val);
-    _textFieldController.text = val == null ? '' : dateFormat.format(val);
+  void didChange(DateTime val) {
+    super.didChange(val);
+    _textFieldController.text = val == null ? '' : _dateFormat.format(val);
   }
 }


### PR DESCRIPTION
* Fix: Added `DateTimeField.onChange` hook to resolve #548 
* Fix: Canceling a `DateTimePicker` now behaves correctly
* Fix: Locale override for `DateTimePicker`
* Fix: `FormBuilderDateRangePicker.initState`
* Example: Add `DateTimePicker` with a Spanish locale to prove locale override works