### PR TITLE
Fixed initState for File Picker and Location fields

### DIFF
--- a/lib/src/fields/form_builder_file_picker.dart
+++ b/lib/src/fields/form_builder_file_picker.dart
@@ -139,8 +139,8 @@ class _FormBuilderFilePickerState
 
   @override
   void initState() {
-    _files = widget.initialValue ?? [];
     super.initState();
+    _files = widget.initialValue ?? [];
   }
 
   Future<void> pickFiles(FormFieldState<List<PlatformFile>> field) async {

--- a/lib/src/widgets/location_field_dialog.dart
+++ b/lib/src/widgets/location_field_dialog.dart
@@ -86,13 +86,13 @@ class _LocationFieldDialogState extends State<LocationFieldDialog> {
 
   @override
   void initState() {
+    super.initState();
     _initialCameraPosition = widget.initialCameraPosition ??
         CameraPosition(
           target: LatLng(37.42796133580664, -122.085749655962),
           zoom: 14.4746,
         );
     _value = _initialCameraPosition;
-    super.initState();
   }
 
   @override


### PR DESCRIPTION
* `initState` must call `super.initState` first, not last