### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Column(
             initialValue: 1,
             max: 5,
           ),
-          FormBuilderCheckboxList(
+          FormBuilderCheckboxGroup(
             decoration:
             InputDecoration(labelText: "The language of my people"),
             attribute: "languages",


### PR DESCRIPTION
FormBuilderCheckboxList is now deprecated. It has been replaced with FormBuilderCheckboxGroup.