### PR TITLE
Fix: FocusNode parameters

### DIFF
--- a/lib/src/fields/form_builder_color_picker.dart
+++ b/lib/src/fields/form_builder_color_picker.dart
@@ -101,7 +101,6 @@ class FormBuilderColorPickerField extends FormBuilderField<Color> {
     this.maxLength,
     this.onEditingComplete,
     this.onFieldSubmitted,
-    // FormFieldValidator<String> validator,
     this.inputFormatters,
     this.cursorWidth = 2.0,
     this.cursorRadius,
@@ -122,6 +121,7 @@ class FormBuilderColorPickerField extends FormBuilderField<Color> {
           enabled: enabled,
           onReset: onReset,
           decoration: decoration,
+          focusNode: focusNode,
           builder: (FormFieldState<Color> field) {
             final state = field as _FormBuilderColorPickerFieldState;
             return TextField(
@@ -201,6 +201,7 @@ class _FormBuilderColorPickerFieldState
 
   @override
   void dispose() {
+    effectiveFocusNode.removeListener(_handleFocus);
     // Dispose the _effectiveController when initState created it
     if (null == widget.controller) {
       _effectiveController.dispose();

--- a/lib/src/fields/form_builder_date_range_picker.dart
+++ b/lib/src/fields/form_builder_date_range_picker.dart
@@ -198,6 +198,7 @@ class FormBuilderDateRangePickerState
 
   @override
   void dispose() {
+    effectiveFocusNode.removeListener(_handleFocus);
     // Dispose the _effectiveController when initState created it
     if (null == widget.controller) {
       _effectiveController.dispose();

--- a/lib/src/fields/form_builder_dropdown.dart
+++ b/lib/src/fields/form_builder_dropdown.dart
@@ -224,6 +224,7 @@ class FormBuilderDropdown<T> extends FormBuilderField<T> {
           enabled: enabled,
           onReset: onReset,
           decoration: decoration,
+          focusNode: focusNode,
           builder: (FormFieldState<T> field) {
             final state = field as _FormBuilderDropdownState<T>;
             // DropdownButtonFormField
@@ -265,8 +266,9 @@ class FormBuilderDropdown<T> extends FormBuilderField<T> {
                         icon: icon,
                         iconDisabledColor: iconDisabledColor,
                         iconEnabledColor: iconEnabledColor,
-                        onChanged:
-                        state.enabled ? (value) => changeValue(value) : null,
+                        onChanged: state.enabled
+                            ? (value) => changeValue(value)
+                            : null,
                         onTap: onTap,
                         focusNode: state.effectiveFocusNode,
                         autofocus: autofocus,

--- a/lib/src/fields/form_builder_phone_field.dart
+++ b/lib/src/fields/form_builder_phone_field.dart
@@ -120,6 +120,7 @@ class FormBuilderPhoneField extends FormBuilderField<String> {
           enabled: enabled,
           onReset: onReset,
           decoration: decoration,
+          focusNode: focusNode,
           builder: (FormFieldState<String> field) {
             final state = field as _FormBuilderPhoneFieldState;
 

--- a/lib/src/fields/form_builder_range_slider.dart
+++ b/lib/src/fields/form_builder_range_slider.dart
@@ -143,6 +143,7 @@ class FormBuilderRangeSlider extends FormBuilderField<RangeValues> {
             enabled: enabled,
             onReset: onReset,
             decoration: decoration,
+            focusNode: focusNode,
             builder: (FormFieldState<RangeValues> field) {
               final state = field as _FormBuilderRangeSliderState;
               final _numberFormat = numberFormat ?? NumberFormat.compact();

--- a/lib/src/fields/form_builder_rating.dart
+++ b/lib/src/fields/form_builder_rating.dart
@@ -67,6 +67,7 @@ class FormBuilderRating extends FormBuilderField<double> {
           enabled: enabled,
           onReset: onReset,
           decoration: decoration,
+          focusNode: focusNode,
           builder: (FormFieldState<double> field) {
             final state = field as _FormBuilderRateState;
             final widget = state.widget;

--- a/lib/src/fields/form_builder_searchable_dropdown.dart
+++ b/lib/src/fields/form_builder_searchable_dropdown.dart
@@ -156,6 +156,7 @@ class FormBuilderSearchableDropdown<T> extends FormBuilderField<T> {
           enabled: enabled,
           onReset: onReset,
           decoration: decoration,
+          focusNode: focusNode,
           builder: (FormFieldState<T> field) {
             final state = field as _FormBuilderSearchableDropdownState<T>;
 

--- a/lib/src/fields/form_builder_segmented_control.dart
+++ b/lib/src/fields/form_builder_segmented_control.dart
@@ -67,6 +67,7 @@ class FormBuilderSegmentedControl<T> extends FormBuilderField<T> {
           enabled: enabled,
           onReset: onReset,
           decoration: decoration,
+          focusNode: focusNode,
           builder: (FormFieldState<T> field) {
             final state = field as _FormBuilderSegmentedControlState<T>;
             final theme = Theme.of(state.context);

--- a/lib/src/fields/form_builder_signature_pad.dart
+++ b/lib/src/fields/form_builder_signature_pad.dart
@@ -58,11 +58,13 @@ class FormBuilderSignaturePad extends FormBuilderField<Uint8List> {
           enabled: enabled,
           onReset: onReset,
           decoration: decoration,
+          focusNode: focusNode,
           builder: (FormFieldState<Uint8List> field) {
             final state = field as _FormBuilderSignaturePadState;
             final theme = Theme.of(state.context);
             final localizations = MaterialLocalizations.of(state.context);
-            final cancelButtonColor = state.enabled ? theme.errorColor : theme.disabledColor;
+            final cancelButtonColor =
+                state.enabled ? theme.errorColor : theme.disabledColor;
 
             return InputDecorator(
               decoration: state.decoration(),
@@ -85,10 +87,12 @@ class FormBuilderSignaturePad extends FormBuilderField<Uint8List> {
                     children: <Widget>[
                       Expanded(child: const SizedBox()),
                       TextButton.icon(
-                        onPressed: state.enabled ? () {
-                          state._controller.clear();
-                          field.didChange(null);
-                        } : null,
+                        onPressed: state.enabled
+                            ? () {
+                                state._controller.clear();
+                                field.didChange(null);
+                              }
+                            : null,
                         label: Text(
                           clearButtonText ?? localizations.cancelButtonLabel,
                           style: TextStyle(color: cancelButtonColor),

--- a/lib/src/fields/form_builder_slider.dart
+++ b/lib/src/fields/form_builder_slider.dart
@@ -169,6 +169,7 @@ class FormBuilderSlider extends FormBuilderField<double> {
           enabled: enabled,
           onReset: onReset,
           decoration: decoration,
+          focusNode: focusNode,
           builder: (FormFieldState<double> field) {
             final state = field as _FormBuilderSliderState;
             final _numberFormat = numberFormat ?? NumberFormat.compact();

--- a/lib/src/fields/form_builder_switch.dart
+++ b/lib/src/fields/form_builder_switch.dart
@@ -119,6 +119,7 @@ class FormBuilderSwitch extends FormBuilderField<bool> {
           enabled: enabled,
           onReset: onReset,
           decoration: decoration,
+          focusNode: focusNode,
           builder: (FormFieldState<bool> field) {
             final state = field as _FormBuilderSwitchState;
 

--- a/lib/src/fields/form_builder_typeahead.dart
+++ b/lib/src/fields/form_builder_typeahead.dart
@@ -294,7 +294,6 @@ class FormBuilderTypeAhead<T> extends FormBuilderField<T> {
     this.keepSuggestionsOnSuggestionSelected = false,
     this.onSuggestionSelected,
     this.controller,
-    // this.onSaved,
   })  : assert(T == String || selectionToTextTransformer != null),
         super(
           key: key,
@@ -308,6 +307,7 @@ class FormBuilderTypeAhead<T> extends FormBuilderField<T> {
           enabled: enabled,
           onReset: onReset,
           decoration: decoration,
+          focusNode: focusNode,
           builder: (FormFieldState<T> field) {
             final state = field as _FormBuilderTypeAheadState<T>;
             final theme = Theme.of(state.context);


### PR DESCRIPTION
* `focusNode` parameters were not always being passed to the super class.
* _Color Picker_ and _Date Range Picker_ were adding a focus node listener during `initState`, but not removing it during `dispose`.