### PR TITLE
Made FormBuilderField non-abstract to allow creating custom input fields

### DIFF
--- a/example/lib/sources/signup_form.dart
+++ b/example/lib/sources/signup_form.dart
@@ -76,6 +76,31 @@ class _SignupFormState extends State<SignupForm> {
                   ]),
                 ),
                 const SizedBox(height: 10),
+                FormBuilderField<bool>(
+                  name: 'test',
+                  validator: FormBuilderValidators.compose([
+                    FormBuilderValidators.required(context),
+                    FormBuilderValidators.equal(context, true),
+                  ]),
+                  // initialValue: true,
+                  decoration: InputDecoration(labelText: 'Accept Terms?'),
+                  builder: (FormFieldState _field) {
+                    return InputDecorator(
+                      decoration: InputDecoration(
+                        errorText: _field.errorText,
+                      ),
+                      child: SwitchListTile(
+                        title: Text(
+                            'I have read and accept the terms of service.'),
+                        onChanged: (bool value) {
+                          _field.didChange(value);
+                        },
+                        value: _field.value ?? false,
+                      ),
+                    );
+                  },
+                ),
+                const SizedBox(height: 10),
                 MaterialButton(
                   color: Theme.of(context).accentColor,
                   child: Text(
@@ -88,6 +113,7 @@ class _SignupFormState extends State<SignupForm> {
                     } else {
                       print('Invalid');
                     }
+                    print(_formKey.currentState.value);
                   },
                 )
               ],

--- a/example/lib/sources/signup_form.dart
+++ b/example/lib/sources/signup_form.dart
@@ -84,18 +84,18 @@ class _SignupFormState extends State<SignupForm> {
                   ]),
                   // initialValue: true,
                   decoration: InputDecoration(labelText: 'Accept Terms?'),
-                  builder: (FormFieldState _field) {
+                  builder: (FormFieldState<bool> field) {
                     return InputDecorator(
                       decoration: InputDecoration(
-                        errorText: _field.errorText,
+                        errorText: field.errorText,
                       ),
                       child: SwitchListTile(
                         title: Text(
                             'I have read and accept the terms of service.'),
                         onChanged: (bool value) {
-                          _field.didChange(value);
+                          field.didChange(value);
                         },
-                        value: _field.value ?? false,
+                        value: field.value ?? false,
                       ),
                     );
                   },

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -9,7 +9,7 @@ enum ControlAffinity { leading, trailing }
 ///
 /// This widget maintains the current state of the form field, so that updates
 /// and validation errors are visually reflected in the UI.
-abstract class FormBuilderField<T> extends FormField<T> {
+class FormBuilderField<T> extends FormField<T> {
   /// Used to reference the field within the form, or to reference form data
   /// after the form is submitted.
   final String name;
@@ -73,11 +73,14 @@ abstract class FormBuilderField<T> extends FormField<T> {
           validator: validator,
         );
 
+  /*@override
+  FormBuilderFieldState<T> createState();*/
   @override
-  FormFieldState<T> createState();
+  FormBuilderFieldState<FormBuilderField<T>, T> createState() =>
+      FormBuilderFieldState<FormBuilderField<T>, T>();
 }
 
-abstract class FormBuilderFieldState<F extends FormBuilderField<T>, T>
+class FormBuilderFieldState<F extends FormBuilderField<T>, T>
     extends FormFieldState<T> {
   @override
   F get widget => super.widget as F;


### PR DESCRIPTION
If `FormBuilderField` is abstract, it can't be used to create a custom field type as we've claimed in README