### PR TITLE
Upgraded the Dart SDK constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 4.0.2
 homepage: https://github.com/danvick/flutter_form_builder
 
 environment:
-  sdk: ">=2.6.0 <3.0.0"
+  sdk: ">=2.10.0 <3.0.0"
   flutter: ">=1.22.0"
 
 dependencies:


### PR DESCRIPTION
* Dart 2.7 is the absolute minimum because extension methods are used.
* However, we are really only testing against Dart 2.10 and later, and require a recent Flutter, so making the constraint 2.10+.