### PR TITLE
Add FormBuilderValidators.notEqual validator

### DIFF
--- a/lib/localization/form_builder_localizations.dart
+++ b/lib/localization/form_builder_localizations.dart
@@ -45,6 +45,13 @@ class FormBuilderLocalizations {
         desc: 'Error Text for equal validator',
       );
 
+  String notEqualErrorText<T>(T value) => Intl.message(
+        'This field value must not be equal to $value.',
+        name: 'notEqualErrorText',
+        args: [value],
+        desc: 'Error Text for not-equal validator',
+      );
+
   String minErrorText(num min) => Intl.message(
         'Value must be greater than or equal to $min.',
         name: 'minErrorText',

--- a/lib/src/form_builder_validators.dart
+++ b/lib/src/form_builder_validators.dart
@@ -49,6 +49,17 @@ class FormBuilderValidators {
               FormBuilderLocalizations.of(context).equalErrorText(value)
           : null;
 
+  /// [FormFieldValidator] that requires the field's value be not equal to
+  /// the provided value.
+  static FormFieldValidator<T> notEqual<T>(
+    BuildContext context,
+    T value, {
+    String errorText,
+  }) =>
+      (valueCandidate) => valueCandidate == value
+          ? errorText ?? FormBuilderLocalizations.of(context).notEqualErrorText(value)
+          : null;
+
   /// [FormFieldValidator] that requires the field's value to be greater than
   /// (or equal) to the provided number.
   static FormFieldValidator<T> min<T>(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_form_builder
 description: This package helps in creation of forms in Flutter by removing the boilerplate code, reusing validation, react to changes, and collect final user input.
-version: 4.0.2
+version: 4.0.2+1
 homepage: https://github.com/danvick/flutter_form_builder
 
 environment:
@@ -20,7 +20,7 @@ dependencies:
   dropdown_search: ^0.4.8
   file_picker: ^2.1.0
   flutter_colorpicker: ^0.3.4
-  flutter_chips_input: ^1.9.4
+  flutter_chips_input: ^1.9.5
   flutter_datetime_picker: ^1.4.0
   flutter_touch_spin: ^1.0.1
   flutter_typeahead: ^1.9.1

--- a/test/form_builder_validators_test.dart
+++ b/test/form_builder_validators_test.dart
@@ -92,6 +92,17 @@ void main() {
           }));
 
   testWidgets(
+      'FormBuilderValidators.notEqual',
+      (WidgetTester tester) => testValidations(tester, (context) {
+            final validator = FormBuilderValidators.notEqual(context, true);
+            // Pass
+            expect(validator(false), isNull);
+            expect(validator(null), isNull);
+            // Fail
+            expect(validator(true), isNotNull);
+          }));
+
+  testWidgets(
       'FormBuilderValidators.maxLength',
       (WidgetTester tester) => testValidations(tester, (context) {
             final validator = FormBuilderValidators.maxLength(context, 5);


### PR DESCRIPTION
For ensuring a value is not-equal to a given value.

Slightly more elegant & eloquent than manually implementing a function for this.