### PR TITLE
Fix #714: TypeAhead onReset uses valueTransformer

### DIFF
--- a/lib/src/fields/form_builder_typeahead.dart
+++ b/lib/src/fields/form_builder_typeahead.dart
@@ -415,6 +415,11 @@ class _FormBuilderTypeAheadState<T>
   @override
   void reset() {
     super.reset();
-    _typeAheadController.text = initialValue?.toString();
+    if (widget.valueTransformer != null) {
+      _typeAheadController.text =
+          widget.valueTransformer(initialValue)?.toString();
+    } else {
+      _typeAheadController.text = initialValue?.toString();
+    }
   }
 }


### PR DESCRIPTION
Fixes issue #714


WHEN I reset the FormBuilder (eg, formKey.currentState.reset();)
AND the form contains a FormBuilderTypeAhead<T>
AND <T> is not a String
THEN the TextController gets reset to the initialValue?.toString()

EXPECTED the TextController should first attempt to reset to widget.valueTransformer(initialValue) if its valueTransformer is not null so that it displays correct information.