### PR TITLE
Fix #313, A FocusNode was used after being disposed

### DIFF
--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -177,7 +177,7 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   }
 
   void requestFocus() {
-    FocusScope.of(context).requestFocus(effectiveFocusNode);
+    FocusScope.of(context).unfocus();
   }
 
   //  FIXME: This  could be a getter instead of a classic function


### PR DESCRIPTION
reference: https://stackoverflow.com/questions/44991968/how-can-i-dismiss-the-on-screen-keyboard