### PR TITLE
Make ValueChanged type nullable to match FormField

### DIFF
--- a/lib/src/fields/form_builder_checkbox.dart
+++ b/lib/src/fields/form_builder_checkbox.dart
@@ -79,7 +79,7 @@ class FormBuilderCheckbox extends FormBuilderField<bool> {
       errorBorder: InputBorder.none,
       disabledBorder: InputBorder.none,
     ),
-    ValueChanged<bool>? onChanged,
+    ValueChanged<bool?>? onChanged,
     ValueTransformer<bool>? valueTransformer,
     bool enabled = true,
     FormFieldSetter<bool>? onSaved,

--- a/lib/src/fields/form_builder_checkbox_group.dart
+++ b/lib/src/fields/form_builder_checkbox_group.dart
@@ -33,7 +33,7 @@ class FormBuilderCheckboxGroup<T> extends FormBuilderField<List<T>> {
     FormFieldValidator<List<T>>? validator,
     List<T>? initialValue,
     InputDecoration decoration = const InputDecoration(),
-    ValueChanged<List<T>>? onChanged,
+    ValueChanged<List<T>?>? onChanged,
     ValueTransformer<List<T>>? valueTransformer,
     bool enabled = true,
     FormFieldSetter<List<T>>? onSaved,

--- a/lib/src/fields/form_builder_choice_chips.dart
+++ b/lib/src/fields/form_builder_choice_chips.dart
@@ -247,7 +247,7 @@ class FormBuilderChoiceChip<T> extends FormBuilderField<T> {
     FormFieldValidator<T>? validator,
     T? initialValue,
     InputDecoration decoration = const InputDecoration(),
-    ValueChanged<T>? onChanged,
+    ValueChanged<T?>? onChanged,
     ValueTransformer<T>? valueTransformer,
     bool enabled = true,
     FormFieldSetter<T>? onSaved,

--- a/lib/src/fields/form_builder_date_range_picker.dart
+++ b/lib/src/fields/form_builder_date_range_picker.dart
@@ -68,7 +68,7 @@ class FormBuilderDateRangePicker extends FormBuilderField<DateTimeRange> {
     FormFieldValidator<DateTimeRange>? validator,
     DateTimeRange? initialValue,
     InputDecoration decoration = const InputDecoration(),
-    ValueChanged<DateTimeRange>? onChanged,
+    ValueChanged<DateTimeRange?>? onChanged,
     ValueTransformer<DateTimeRange>? valueTransformer,
     bool enabled = true,
     FormFieldSetter<DateTimeRange>? onSaved,

--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -135,7 +135,7 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
     FormFieldValidator<DateTime>? validator,
     DateTime? initialValue,
     InputDecoration decoration = const InputDecoration(),
-    ValueChanged<DateTime>? onChanged,
+    ValueChanged<DateTime?>? onChanged,
     ValueTransformer<DateTime>? valueTransformer,
     bool enabled = true,
     FormFieldSetter<DateTime>? onSaved,

--- a/lib/src/fields/form_builder_dropdown.dart
+++ b/lib/src/fields/form_builder_dropdown.dart
@@ -189,7 +189,7 @@ class FormBuilderDropdown<T> extends FormBuilderField<T> {
     FormFieldValidator<T>? validator,
     T? initialValue,
     InputDecoration decoration = const InputDecoration(),
-    ValueChanged<T>? onChanged,
+    ValueChanged<T?>? onChanged,
     ValueTransformer<T>? valueTransformer,
     bool enabled = true,
     FormFieldSetter<T>? onSaved,

--- a/lib/src/fields/form_builder_filter_chips.dart
+++ b/lib/src/fields/form_builder_filter_chips.dart
@@ -47,7 +47,7 @@ class FormBuilderFilterChip<T> extends FormBuilderField<List<T>> {
       errorBorder: InputBorder.none,
       disabledBorder: InputBorder.none,
     ),
-    ValueChanged<List<T>>? onChanged,
+    ValueChanged<List<T>?>? onChanged,
     ValueTransformer<List<T>>? valueTransformer,
     bool enabled = true,
     FormFieldSetter<List<T>>? onSaved,

--- a/lib/src/fields/form_builder_radio_group.dart
+++ b/lib/src/fields/form_builder_radio_group.dart
@@ -31,7 +31,7 @@ class FormBuilderRadioGroup<T> extends FormBuilderField<T> {
     FormFieldValidator<T>? validator,
     T? initialValue,
     InputDecoration decoration = const InputDecoration(),
-    ValueChanged<T>? onChanged,
+    ValueChanged<T?>? onChanged,
     ValueTransformer<T>? valueTransformer,
     bool enabled = true,
     FormFieldSetter<T>? onSaved,

--- a/lib/src/fields/form_builder_range_slider.dart
+++ b/lib/src/fields/form_builder_range_slider.dart
@@ -112,7 +112,7 @@ class FormBuilderRangeSlider extends FormBuilderField<RangeValues> {
     FormFieldValidator<RangeValues>? validator,
     RangeValues? initialValue,
     InputDecoration decoration = const InputDecoration(),
-    ValueChanged<RangeValues>? onChanged,
+    ValueChanged<RangeValues?>? onChanged,
     ValueTransformer<RangeValues>? valueTransformer,
     bool enabled = true,
     FormFieldSetter<RangeValues>? onSaved,

--- a/lib/src/fields/form_builder_segmented_control.dart
+++ b/lib/src/fields/form_builder_segmented_control.dart
@@ -45,7 +45,7 @@ class FormBuilderSegmentedControl<T extends Object>
     FormFieldValidator<T>? validator,
     T? initialValue,
     InputDecoration decoration = const InputDecoration(),
-    ValueChanged<T>? onChanged,
+    ValueChanged<T?>? onChanged,
     ValueTransformer<T>? valueTransformer,
     bool enabled = true,
     FormFieldSetter<T>? onSaved,

--- a/lib/src/fields/form_builder_slider.dart
+++ b/lib/src/fields/form_builder_slider.dart
@@ -136,7 +136,7 @@ class FormBuilderSlider extends FormBuilderField<double> {
     FormFieldValidator<double>? validator,
     required double initialValue,
     InputDecoration decoration = const InputDecoration(),
-    ValueChanged<double>? onChanged,
+    ValueChanged<double?>? onChanged,
     ValueTransformer<double>? valueTransformer,
     bool enabled = true,
     FormFieldSetter<double>? onSaved,

--- a/lib/src/fields/form_builder_switch.dart
+++ b/lib/src/fields/form_builder_switch.dart
@@ -89,7 +89,7 @@ class FormBuilderSwitch extends FormBuilderField<bool> {
     FormFieldValidator<bool>? validator,
     bool? initialValue,
     InputDecoration decoration = const InputDecoration(),
-    ValueChanged<bool>? onChanged,
+    ValueChanged<bool?>? onChanged,
     ValueTransformer<bool>? valueTransformer,
     bool enabled = true,
     FormFieldSetter<bool>? onSaved,

--- a/lib/src/fields/form_builder_text_field.dart
+++ b/lib/src/fields/form_builder_text_field.dart
@@ -68,7 +68,7 @@ class FormBuilderTextField extends FormBuilderField<String> {
   final bool enableSuggestions;
 
   /// {@macro flutter.widgets.editableText.maxLines}
-  final int maxLines;
+  final int? maxLines;
 
   /// {@macro flutter.widgets.editableText.minLines}
   final int? minLines;
@@ -344,7 +344,7 @@ class FormBuilderTextField extends FormBuilderField<String> {
   })  : assert(initialValue == null || controller == null),
         assert(minLines == null || minLines > 0),
         assert(
-          (minLines == null) || (maxLines >= minLines),
+          (minLines == null) || (maxLines! >= minLines),
           'minLines can\'t be greater than maxLines',
         ),
         assert(

--- a/lib/src/fields/form_builder_text_field.dart
+++ b/lib/src/fields/form_builder_text_field.dart
@@ -68,7 +68,7 @@ class FormBuilderTextField extends FormBuilderField<String> {
   final bool enableSuggestions;
 
   /// {@macro flutter.widgets.editableText.maxLines}
-  final int? maxLines;
+  final int maxLines;
 
   /// {@macro flutter.widgets.editableText.minLines}
   final int? minLines;
@@ -344,7 +344,7 @@ class FormBuilderTextField extends FormBuilderField<String> {
   })  : assert(initialValue == null || controller == null),
         assert(minLines == null || minLines > 0),
         assert(
-          (minLines == null) || (maxLines! >= minLines),
+          (minLines == null) || (maxLines >= minLines),
           'minLines can\'t be greater than maxLines',
         ),
         assert(

--- a/lib/src/fields/form_builder_text_field.dart
+++ b/lib/src/fields/form_builder_text_field.dart
@@ -293,7 +293,7 @@ class FormBuilderTextField extends FormBuilderField<String> {
     String? initialValue,
     bool readOnly = false,
     InputDecoration decoration = const InputDecoration(),
-    ValueChanged<String>? onChanged,
+    ValueChanged<String?>? onChanged,
     ValueTransformer<String>? valueTransformer,
     bool enabled = true,
     FormFieldSetter<String>? onSaved,

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -33,7 +33,7 @@ class FormBuilderField<T> extends FormField<T?> {
   final ValueTransformer<T>? valueTransformer;
 
   /// Called when the field value is changed.
-  final ValueChanged<T>? onChanged;
+  final ValueChanged<T?>? onChanged;
 
   /// The border, labels, icons, and styles used to decorate the field.
   final InputDecoration decoration;


### PR DESCRIPTION
This fixes an issue where the onChanged event fails with a null value exception e.g. for DateTimePicker you get: Unhandled Exception: type '(DateTime) => void' is not a subtype of type '((DateTime?) => void)?'