### PR TITLE
Allow customized handling of field's error status and text

### DIFF
--- a/lib/src/fields/form_builder_checkbox.dart
+++ b/lib/src/fields/form_builder_checkbox.dart
@@ -85,6 +85,8 @@ class FormBuilderCheckbox extends FormBuilderField<bool> {
     FormFieldSetter<bool?>? onSaved,
     AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
     VoidCallback? onReset,
+    BoolCallback? hasError,
+    BoolCallback? isValid,
     FocusNode? focusNode,
     required this.title,
     this.activeColor,
@@ -107,6 +109,8 @@ class FormBuilderCheckbox extends FormBuilderField<bool> {
           onSaved: onSaved,
           enabled: enabled,
           onReset: onReset,
+          hasError: hasError,
+          isValid: isValid,
           decoration: decoration,
           focusNode: focusNode,
           builder: (FormFieldState<bool?> field) {

--- a/lib/src/fields/form_builder_checkbox_group.dart
+++ b/lib/src/fields/form_builder_checkbox_group.dart
@@ -39,6 +39,8 @@ class FormBuilderCheckboxGroup<T> extends FormBuilderField<List<T>> {
     FormFieldSetter<List<T>>? onSaved,
     AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
     VoidCallback? onReset,
+    BoolCallback? hasError,
+    BoolCallback? isValid,
     FocusNode? focusNode,
     required this.options,
     this.activeColor,
@@ -70,6 +72,8 @@ class FormBuilderCheckboxGroup<T> extends FormBuilderField<List<T>> {
           onSaved: onSaved,
           enabled: enabled,
           onReset: onReset,
+          hasError: hasError,
+          isValid: isValid,
           decoration: decoration,
           focusNode: focusNode,
           builder: (FormFieldState<List<T>?> field) {

--- a/lib/src/fields/form_builder_choice_chips.dart
+++ b/lib/src/fields/form_builder_choice_chips.dart
@@ -253,6 +253,8 @@ class FormBuilderChoiceChip<T> extends FormBuilderField<T> {
     FormFieldSetter<T>? onSaved,
     AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
     VoidCallback? onReset,
+    BoolCallback? hasError,
+    BoolCallback? isValid,
     FocusNode? focusNode,
     required this.options,
     this.selectedColor,
@@ -287,6 +289,8 @@ class FormBuilderChoiceChip<T> extends FormBuilderField<T> {
             onSaved: onSaved,
             enabled: enabled,
             onReset: onReset,
+            hasError: hasError,
+            isValid: isValid,
             decoration: decoration,
             focusNode: focusNode,
             builder: (FormFieldState<T?> field) {

--- a/lib/src/fields/form_builder_date_range_picker.dart
+++ b/lib/src/fields/form_builder_date_range_picker.dart
@@ -74,6 +74,8 @@ class FormBuilderDateRangePicker extends FormBuilderField<DateTimeRange> {
     FormFieldSetter<DateTimeRange>? onSaved,
     AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
     VoidCallback? onReset,
+    BoolCallback? hasError,
+    BoolCallback? isValid,
     FocusNode? focusNode,
     required this.firstDate,
     required this.lastDate,
@@ -134,6 +136,8 @@ class FormBuilderDateRangePicker extends FormBuilderField<DateTimeRange> {
           onSaved: onSaved,
           enabled: enabled,
           onReset: onReset,
+          hasError: hasError,
+          isValid: isValid,
           decoration: decoration,
           focusNode: focusNode,
           builder: (FormFieldState<DateTimeRange?> field) {

--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -141,6 +141,8 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
     FormFieldSetter<DateTime>? onSaved,
     AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
     VoidCallback? onReset,
+    BoolCallback? hasError,
+    BoolCallback? isValid,
     FocusNode? focusNode,
     this.inputType = InputType.both,
     this.scrollPadding = const EdgeInsets.all(20.0),
@@ -204,6 +206,8 @@ class FormBuilderDateTimePicker extends FormBuilderField<DateTime> {
           onSaved: onSaved,
           enabled: enabled,
           onReset: onReset,
+          hasError: hasError,
+          isValid: isValid,
           decoration: decoration,
           focusNode: focusNode,
           builder: (FormFieldState<DateTime?> field) {

--- a/lib/src/fields/form_builder_dropdown.dart
+++ b/lib/src/fields/form_builder_dropdown.dart
@@ -195,6 +195,8 @@ class FormBuilderDropdown<T> extends FormBuilderField<T> {
     FormFieldSetter<T>? onSaved,
     AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
     VoidCallback? onReset,
+    BoolCallback? hasError,
+    BoolCallback? isValid,
     FocusNode? focusNode,
     required this.items,
     this.isExpanded = true,
@@ -226,6 +228,8 @@ class FormBuilderDropdown<T> extends FormBuilderField<T> {
           onSaved: onSaved,
           enabled: enabled,
           onReset: onReset,
+          hasError: hasError,
+          isValid: isValid,
           decoration: decoration,
           focusNode: focusNode,
           builder: (FormFieldState<T?> field) {

--- a/lib/src/fields/form_builder_filter_chips.dart
+++ b/lib/src/fields/form_builder_filter_chips.dart
@@ -53,6 +53,8 @@ class FormBuilderFilterChip<T> extends FormBuilderField<List<T>> {
     FormFieldSetter<List<T>>? onSaved,
     AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
     VoidCallback? onReset,
+    BoolCallback? hasError,
+    BoolCallback? isValid,
     FocusNode? focusNode,
     required this.options,
     this.selectedColor,
@@ -92,6 +94,8 @@ class FormBuilderFilterChip<T> extends FormBuilderField<List<T>> {
           onSaved: onSaved,
           enabled: enabled,
           onReset: onReset,
+          hasError: hasError,
+          isValid: isValid,
           decoration: decoration,
           focusNode: focusNode,
           builder: (FormFieldState<List<T>?> field) {

--- a/lib/src/fields/form_builder_radio_group.dart
+++ b/lib/src/fields/form_builder_radio_group.dart
@@ -37,6 +37,8 @@ class FormBuilderRadioGroup<T> extends FormBuilderField<T> {
     FormFieldSetter<T>? onSaved,
     AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
     VoidCallback? onReset,
+    BoolCallback? hasError,
+    BoolCallback? isValid,
     FocusNode? focusNode,
     required this.options,
     this.activeColor,
@@ -66,6 +68,8 @@ class FormBuilderRadioGroup<T> extends FormBuilderField<T> {
           onSaved: onSaved,
           enabled: enabled,
           onReset: onReset,
+          hasError: hasError,
+          isValid: isValid,
           focusNode: focusNode,
           decoration: decoration,
           builder: (FormFieldState<T?> field) {

--- a/lib/src/fields/form_builder_range_slider.dart
+++ b/lib/src/fields/form_builder_range_slider.dart
@@ -118,6 +118,8 @@ class FormBuilderRangeSlider extends FormBuilderField<RangeValues> {
     FormFieldSetter<RangeValues>? onSaved,
     AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
     VoidCallback? onReset,
+    BoolCallback? hasError,
+    BoolCallback? isValid,
     FocusNode? focusNode,
     required this.min,
     required this.max,
@@ -144,6 +146,8 @@ class FormBuilderRangeSlider extends FormBuilderField<RangeValues> {
             onSaved: onSaved,
             enabled: enabled,
             onReset: onReset,
+            hasError: hasError,
+            isValid: isValid,
             decoration: decoration,
             focusNode: focusNode,
             builder: (FormFieldState<RangeValues?> field) {

--- a/lib/src/fields/form_builder_segmented_control.dart
+++ b/lib/src/fields/form_builder_segmented_control.dart
@@ -51,6 +51,8 @@ class FormBuilderSegmentedControl<T extends Object>
     FormFieldSetter<T>? onSaved,
     AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
     VoidCallback? onReset,
+    BoolCallback? hasError,
+    BoolCallback? isValid,
     FocusNode? focusNode,
     required this.options,
     this.borderColor,
@@ -69,6 +71,8 @@ class FormBuilderSegmentedControl<T extends Object>
           onSaved: onSaved,
           enabled: enabled,
           onReset: onReset,
+          hasError: hasError,
+          isValid: isValid,
           decoration: decoration,
           focusNode: focusNode,
           builder: (FormFieldState<T?> field) {

--- a/lib/src/fields/form_builder_slider.dart
+++ b/lib/src/fields/form_builder_slider.dart
@@ -142,6 +142,8 @@ class FormBuilderSlider extends FormBuilderField<double> {
     FormFieldSetter<double>? onSaved,
     AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
     VoidCallback? onReset,
+    BoolCallback? hasError,
+    BoolCallback? isValid,
     FocusNode? focusNode,
     required this.min,
     required this.max,
@@ -170,6 +172,8 @@ class FormBuilderSlider extends FormBuilderField<double> {
           onSaved: onSaved,
           enabled: enabled,
           onReset: onReset,
+          hasError: hasError,
+          isValid: isValid,
           decoration: decoration,
           focusNode: focusNode,
           builder: (FormFieldState<double?> field) {

--- a/lib/src/fields/form_builder_switch.dart
+++ b/lib/src/fields/form_builder_switch.dart
@@ -95,6 +95,8 @@ class FormBuilderSwitch extends FormBuilderField<bool> {
     FormFieldSetter<bool>? onSaved,
     AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
     VoidCallback? onReset,
+    BoolCallback? hasError,
+    BoolCallback? isValid,
     FocusNode? focusNode,
     required this.title,
     this.activeColor,
@@ -120,6 +122,8 @@ class FormBuilderSwitch extends FormBuilderField<bool> {
           onSaved: onSaved,
           enabled: enabled,
           onReset: onReset,
+          hasError: hasError,
+          isValid: isValid,
           decoration: decoration,
           focusNode: focusNode,
           builder: (FormFieldState<bool?> field) {

--- a/lib/src/fields/form_builder_text_field.dart
+++ b/lib/src/fields/form_builder_text_field.dart
@@ -299,6 +299,8 @@ class FormBuilderTextField extends FormBuilderField<String> {
     FormFieldSetter<String>? onSaved,
     AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
     VoidCallback? onReset,
+    BoolCallback? hasError,
+    BoolCallback? isValid,
     FocusNode? focusNode,
     this.maxLines = 1,
     this.obscureText = false,
@@ -365,6 +367,8 @@ class FormBuilderTextField extends FormBuilderField<String> {
           onSaved: onSaved,
           enabled: enabled,
           onReset: onReset,
+          hasError: hasError,
+          isValid: isValid,
           decoration: decoration,
           focusNode: focusNode,
           builder: (FormFieldState<String?> field) {

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -7,6 +7,9 @@ enum ControlAffinity { leading, trailing }
 
 typedef ValueTransformer<T> = dynamic Function(T value);
 
+/// Typedef for error and validation handling functions.
+typedef BoolCallback = bool Function();
+
 /// A single form field.
 ///
 /// This widget maintains the current state of the form field, so that updates
@@ -43,6 +46,11 @@ class FormBuilderField<T> extends FormField<T?> {
   /// Called when the field value is reset.
   final VoidCallback? onReset;
 
+  /// Callbacks to determine error and validation status,
+  /// for example, in a widget and its state wrapping a form builder field.
+  final BoolCallback? hasError;
+  final BoolCallback? isValid;
+
   /// {@macro flutter.widgets.Focus.focusNode}
   final FocusNode? focusNode;
 
@@ -63,6 +71,8 @@ class FormBuilderField<T> extends FormField<T?> {
     this.onChanged,
     this.decoration = const InputDecoration(),
     this.onReset,
+    this.hasError,
+    this.isValid,
     this.focusNode,
   }) : super(
           key: key,
@@ -99,10 +109,14 @@ class FormBuilderFieldState<F extends FormBuilderField<T?>, T>
   FormBuilderState? _formBuilderState;
 
   @override
-  bool get hasError => super.hasError || widget.decoration.errorText != null;
+  bool get hasError =>
+      widget.hasError?.call() ??
+      (super.hasError || widget.decoration.errorText != null);
 
   @override
-  bool get isValid => super.isValid && widget.decoration.errorText == null;
+  bool get isValid =>
+      widget.isValid?.call() ??
+      (super.isValid && widget.decoration.errorText == null);
 
   bool _touched = false;
 


### PR DESCRIPTION
Allow user to modify field's error status and text between two validations.
Use case:
1) User creates invalid input and validator's error text is shown.
2) User corrects input -> Rebuild widget on the fly -> Error status is still shown.
3) User validates input again -> Error gone.

Now you CAN do the following:
- Always return "null" to the form validation framework and remember potential error in a state class member.
- "hasError" gets called afterwards and can return an appropriate result.
- Now redrawing the widget does only render an error between validations when the input decoration's "errorText" is explicitly and manually set (depending on class' member ). The way form validation works in general does not change this way.

Further, this addition does not break current package behavior.