### PR TITLE
fix: Remove autovalidate flag form Readme.me example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Widget build(BuildContext context) {
     children: <Widget>[
       FormBuilder(
         key: _formKey,
-        autovalidate: true,
+        autovalidateMode: AutovalidateMode.onUserInteraction,
         child: Column(
           children: <Widget>[
             FormBuilderFilterChip(


### PR DESCRIPTION
Hey there.

Just a very very quick PR to adjust the example on README to the proper validation property;

(: 