### PR TITLE
Add showByInt option to FormBuilderSlider

### DIFF
--- a/lib/src/fields/form_builder_slider.dart
+++ b/lib/src/fields/form_builder_slider.dart
@@ -124,6 +124,7 @@ class FormBuilderSlider extends FormBuilderField<double> {
   /// The var used to limit the value SHOWN, not the actual value to an int
   final bool showByInt;
 
+
   ///TODO: Add documentation
   final NumberFormat? numberFormat;
   final DisplayValues displayValues;
@@ -187,7 +188,7 @@ class FormBuilderSlider extends FormBuilderField<double> {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Slider(
-                      value: (showByInt) ? ((field.value!)?.round()).toString() : field.value!,
+                      value: field.value!,
                       min: min,
                       max: max,
                       divisions: divisions,
@@ -219,6 +220,7 @@ class FormBuilderSlider extends FormBuilderField<double> {
                         if (displayValues != DisplayValues.none &&
                             displayValues != DisplayValues.minMax)
                           Text(
+                            (showByInt) ? ((field.value!).round()).toString():
                             _numberFormat.format(field.value),
                             style: textStyle,
                           ),

--- a/lib/src/fields/form_builder_slider.dart
+++ b/lib/src/fields/form_builder_slider.dart
@@ -121,6 +121,9 @@ class FormBuilderSlider extends FormBuilderField<double> {
   /// {@macro flutter.widgets.Focus.autofocus}
   final bool autofocus;
 
+  /// The var used to limit the value SHOWN, not the actual value to an int
+  final bool showByInt;
+
   ///TODO: Add documentation
   final NumberFormat? numberFormat;
   final DisplayValues displayValues;
@@ -145,6 +148,7 @@ class FormBuilderSlider extends FormBuilderField<double> {
     FocusNode? focusNode,
     required this.min,
     required this.max,
+    this.showByInt = false,
     this.divisions,
     this.activeColor,
     this.inactiveColor,
@@ -183,7 +187,7 @@ class FormBuilderSlider extends FormBuilderField<double> {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Slider(
-                      value: field.value!,
+                      value: (showByInt) ? ((field.value!)?.round()).toString() : field.value!,
                       min: min,
                       max: max,
                       divisions: divisions,


### PR DESCRIPTION
This is the second time I've made this PR, because the first one was super wrong. Just adds a Boolean that if true, shows the sliders current value as rounded using round(). Doesn't actually change the value because I couldn't figure out how to do that. It's not great, and totally unnecessary, but I needed it for a project and thought it might be useful to others.