### PR TITLE
feat(validators): added korean language support

### DIFF
--- a/packages/form_builder_validators/lib/l10n/intl_ko.arb
+++ b/packages/form_builder_validators/lib/l10n/intl_ko.arb
@@ -1,12 +1,13 @@
 {
-  "@@last_modified": "2020-11-13T10:38:27.938366",
-  "requiredErrorText": "This field cannot be empty.",
+  "@@last_modified": "2021-11-04T12:24:27.938366",
+  "@@locale": "ko",
+  "requiredErrorText": "이 필드는 반드시 입력해야 합니다.",
   "@requiredErrorText": {
     "description": "Error Text for required validator",
     "type": "text",
     "placeholders": {}
   },
-  "equalErrorText": "This field value must be equal to {value}.",
+  "equalErrorText": "이 필드의 값은 반드시 {value}와 같아야 합니다.",
   "@equalErrorText": {
     "description": "Error Text for equal validator",
     "type": "text",
@@ -14,7 +15,7 @@
       "value": {}
     }
   },
-  "notEqualErrorText": "This field value must not be equal to {value}.",
+  "notEqualErrorText": "이 필드의 값은 반드시 {value}와 달라야 합니다.",
   "@notEqualErrorText": {
     "description": "Error Text for not-equal validator",
     "type": "text",
@@ -22,7 +23,7 @@
       "value": {}
     }
   },
-  "minErrorText": "Value must be greater than or equal to {min}.",
+  "minErrorText": "이 필드의 값은 반드시 {min} 이상이어야 합니다.",
   "@minErrorText": {
     "description": "Error Text for required field",
     "type": "text",
@@ -30,7 +31,7 @@
       "min": {}
     }
   },
-  "minLengthErrorText": "Value must have a length greater than or equal to {minLength}",
+  "minLengthErrorText": "이 필드는 반드시 {minLength}자 이상이어야 합니다.",
   "@minLengthErrorText": {
     "description": "Error Text for minLength validator",
     "type": "text",
@@ -38,7 +39,7 @@
       "minLength": {}
     }
   },
-  "maxErrorText": "Value must be less than or equal to {max}",
+  "maxErrorText": "이 필드의 값은 반드시 {max} 이하이어야 합니다.",
   "@maxErrorText": {
     "description": "Error Text for max validator",
     "type": "text",
@@ -46,7 +47,7 @@
       "max": {}
     }
   },
-  "maxLengthErrorText": "Value must have a length less than or equal to {maxLength}",
+  "maxLengthErrorText": "이 필드는 반드시 {maxLength}자 이하이어야 합니다.",
   "@maxLengthErrorText": {
     "description": "Error Text for required field",
     "type": "text",
@@ -54,49 +55,49 @@
       "maxLength": {}
     }
   },
-  "emailErrorText": "This field requires a valid email address.",
+  "emailErrorText": "이메일 주소 형식이 올바르지 않습니다.",
   "@emailErrorText": {
     "description": "Error Text for email validator",
     "type": "text",
     "placeholders": {}
   },
-  "urlErrorText": "This field requires a valid URL address.",
+  "urlErrorText": "URL 형식이 올바르지 않습니다.",
   "@urlErrorText": {
     "description": "Error Text for URL validator",
     "type": "text",
     "placeholders": {}
   },
-  "matchErrorText": "Value does not match pattern.",
+  "matchErrorText": "필드의 값이 패턴과 맞지 않습니다.",
   "@matchErrorText": {
     "description": "Error Text for pattern validator",
     "type": "text",
     "placeholders": {}
   },
-  "numericErrorText": "Value must be numeric.",
+  "numericErrorText": "숫자만 입력 가능합니다.",
   "@numericErrorText": {
     "description": "Error Text for numeric validator",
     "type": "text",
     "placeholders": {}
   },
-  "integerErrorText": "Value must be an integer.",
+  "integerErrorText": "정수만 입력 가능합니다.",
   "@integerErrorText": {
     "description": "Error Text for integer validator",
     "type": "text",
     "placeholders": {}
   },
-  "creditCardErrorText": "This field requires a valid credit card number.",
+  "creditCardErrorText": "유효한 카드 번호를 입력해 주세요.",
   "@creditCardErrorText": {
     "description": "Error Text for credit card validator",
     "type": "text",
     "placeholders": {}
   },
-  "ipErrorText": "This field requires a valid IP.",
+  "ipErrorText": "유효한 IP를 입력해 주세요.",
   "@ipErrorText": {
     "description": "Error Text for IP address validator",
     "type": "text",
     "placeholders": {}
   },
-  "dateStringErrorText": "This field requires a valid date string.",
+  "dateStringErrorText": "날짜 형식이 올바르지 않습니다.",
   "@dateStringErrorText": {
     "description": "Error Text for date string validator",
     "type": "text",

--- a/packages/form_builder_validators/lib/localization/intl/messages_all.dart
+++ b/packages/form_builder_validators/lib/localization/intl/messages_all.dart
@@ -24,6 +24,7 @@ import 'messages_fr.dart' as messages_fr;
 import 'messages_hu.dart' as messages_hu;
 import 'messages_it.dart' as messages_it;
 import 'messages_ja.dart' as messages_ja;
+import 'messages_ko.dart' as messages_ko;
 import 'messages_messages.dart' as messages_messages;
 import 'messages_pl.dart' as messages_pl;
 import 'messages_pt.dart' as messages_pt;
@@ -40,6 +41,7 @@ Map<String, LibraryLoader> _deferredLibraries = {
   'hu': () => new Future.value(null),
   'it': () => new Future.value(null),
   'ja': () => new Future.value(null),
+  'ko': () => new Future.value(null),
   'messages': () => new Future.value(null),
   'pl': () => new Future.value(null),
   'pt': () => new Future.value(null),
@@ -66,6 +68,8 @@ MessageLookupByLibrary? _findExact(String localeName) {
       return messages_it.messages;
     case 'ja':
       return messages_ja.messages;
+    case 'ko':
+      return messages_ko.messages;
     case 'messages':
       return messages_messages.messages;
     case 'pl':

--- a/packages/form_builder_validators/lib/localization/intl/messages_ko.dart
+++ b/packages/form_builder_validators/lib/localization/intl/messages_ko.dart
@@ -1,0 +1,60 @@
+// DO NOT EDIT. This is code generated via package:intl/generate_localized.dart
+// This is a library that provides messages for a ko locale. All the
+// messages from the main program should be duplicated here with the same
+// function name.
+
+// Ignore issues from commonly used lints in this file.
+// ignore_for_file:unnecessary_brace_in_string_interps, unnecessary_new
+// ignore_for_file:prefer_single_quotes,comment_references, directives_ordering
+// ignore_for_file:annotate_overrides,prefer_generic_function_type_aliases
+// ignore_for_file:unused_import, file_names, avoid_escaping_inner_quotes
+
+import 'package:intl/intl.dart';
+import 'package:intl/message_lookup_by_library.dart';
+
+final messages = new MessageLookup();
+
+typedef String MessageIfAbsent(String messageStr, List<dynamic> args);
+
+class MessageLookup extends MessageLookupByLibrary {
+  String get localeName => 'ko';
+
+  static String m0(value) => "이 필드의 값은 반드시 ${value}와 같아야 합니다.";
+
+  static String m1(max) => "이 필드의 값은 반드시 ${max} 이하이어야 합니다.";
+
+  static String m2(maxLength) => "이 필드는 반드시 ${maxLength}자 이하이어야 합니다.";
+
+  static String m3(min) => "이 필드의 값은 반드시 ${min} 이상이어야 합니다.";
+
+  static String m4(minLength) => "이 필드는 반드시 ${minLength}자 이상이어야 합니다.";
+
+  static String m5(value) => "이 필드의 값은 반드시 ${value}와 달라야 합니다.";
+
+  final messages = _notInlinedMessages(_notInlinedMessages);
+  static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
+        "creditCardErrorText":
+            MessageLookupByLibrary.simpleMessage("유효한 카드 번호를 입력해 주세요."),
+        "dateStringErrorText":
+            MessageLookupByLibrary.simpleMessage("날짜 형식이 올바르지 않습니다."),
+        "emailErrorText":
+            MessageLookupByLibrary.simpleMessage("이메일 주소 형식이 올바르지 않습니다."),
+        "equalErrorText": m0,
+        "integerErrorText":
+            MessageLookupByLibrary.simpleMessage("정수만 입력 가능합니다."),
+        "ipErrorText": MessageLookupByLibrary.simpleMessage("유효한 IP를 입력해 주세요."),
+        "matchErrorText":
+            MessageLookupByLibrary.simpleMessage("필드의 값이 패턴과 맞지 않습니다."),
+        "maxErrorText": m1,
+        "maxLengthErrorText": m2,
+        "minErrorText": m3,
+        "minLengthErrorText": m4,
+        "notEqualErrorText": m5,
+        "numericErrorText":
+            MessageLookupByLibrary.simpleMessage("숫자만 입력 가능합니다."),
+        "requiredErrorText":
+            MessageLookupByLibrary.simpleMessage("이 필드는 반드시 입력해야 합니다."),
+        "urlErrorText":
+            MessageLookupByLibrary.simpleMessage("URL 형식이 올바르지 않습니다.")
+      };
+}

--- a/packages/form_builder_validators/lib/localization/intl/messages_messages.dart
+++ b/packages/form_builder_validators/lib/localization/intl/messages_messages.dart
@@ -31,6 +31,8 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m4(minLength) =>
       "Value must have a length greater than or equal to ${minLength}";
 
+  static String m5(value) => "This field value must not be equal to ${value}.";
+
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
         "creditCardErrorText": MessageLookupByLibrary.simpleMessage(
@@ -50,6 +52,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "maxLengthErrorText": m2,
         "minErrorText": m3,
         "minLengthErrorText": m4,
+        "notEqualErrorText": m5,
         "numericErrorText":
             MessageLookupByLibrary.simpleMessage("Value must be numeric."),
         "requiredErrorText":

--- a/packages/form_builder_validators/lib/localization/l10n.dart
+++ b/packages/form_builder_validators/lib/localization/l10n.dart
@@ -217,6 +217,7 @@ class AppLocalizationDelegate
       Locale.fromSubtags(languageCode: 'hu'),
       Locale.fromSubtags(languageCode: 'it'),
       Locale.fromSubtags(languageCode: 'ja'),
+      Locale.fromSubtags(languageCode: 'ko'),
       Locale.fromSubtags(languageCode: 'messages'),
       Locale.fromSubtags(languageCode: 'pl'),
       Locale.fromSubtags(languageCode: 'pt'),


### PR DESCRIPTION
Motivation
- Korean is not supported.

Modifications
- Write `intl_ko.arb`.
- misc.
  - Add `notEqualErrorText` to `intl_messages.arb` as it was missing unlike others.

Result
- Korean is supported.