### PR TITLE
Support tristate

### DIFF
--- a/packages/flutter_form_builder/lib/src/fields/form_builder_checkbox.dart
+++ b/packages/flutter_form_builder/lib/src/fields/form_builder_checkbox.dart
@@ -117,7 +117,7 @@ class FormBuilderCheckbox extends FormBuilderField<bool> {
                 isThreeLine: false,
                 title: title,
                 subtitle: subtitle,
-                value: state.value ?? false,
+                value: tristate? state.value : (state.value ?? false),
                 onChanged: state.enabled
                     ? (val) {
                         state.requestFocus();


### PR DESCRIPTION
Currently, the `tristate` property is not supported because null values are always discarded in the constructor, Added a check for `tristate` value, if `false`, enforce null-safety, otherwise use the `state.value` as-is.