### PR TITLE
Added optional parameter for requesting focus on value changed

### DIFF
--- a/packages/flutter_form_builder/lib/src/fields/form_builder_checkbox.dart
+++ b/packages/flutter_form_builder/lib/src/fields/form_builder_checkbox.dart
@@ -94,6 +94,7 @@ class FormBuilderCheckbox extends FormBuilderField<bool> {
     this.autofocus = false,
     this.tristate = false,
     this.selected = false,
+    bool focusOnChange=true
   }) : super(
           key: key,
           initialValue: initialValue,
@@ -120,7 +121,7 @@ class FormBuilderCheckbox extends FormBuilderField<bool> {
                 value: tristate? state.value : (state.value ?? false),
                 onChanged: state.enabled
                     ? (val) {
-                        state.requestFocus();
+                        if(focusOnChange) state.requestFocus();
                         state.didChange(val);
                       }
                     : null,


### PR DESCRIPTION
For long lists, checkboxes refocusing themselves after they value looks extremely disorienting. With focusOnChange set to false (default true), checkboxes will no longer request focus when onChanged is called