### PR TITLE
Patch form_builder_range_slider.dart

### DIFF
--- a/packages/flutter_form_builder/lib/src/fields/form_builder_range_slider.dart
+++ b/packages/flutter_form_builder/lib/src/fields/form_builder_range_slider.dart
@@ -109,7 +109,7 @@ class FormBuilderRangeSlider extends FormBuilderField<RangeValues> {
     //From Super
     required String name,
     FormFieldValidator<RangeValues>? validator,
-    RangeValues? initialValue,
+    required RangeValues initialValue,
     InputDecoration decoration = const InputDecoration(),
     ValueChanged<RangeValues?>? onChanged,
     ValueTransformer<RangeValues?>? valueTransformer,


### PR DESCRIPTION
When the initialValue parameter is not provided in the FormBuilderRangeSlider widget, a "null check operator used on a null value" error is displayed. Making initialValue a required parameter fixes this error.