### PR TITLE
Added silent validation to the form_builder Widget

### DIFF
--- a/packages/flutter_form_builder/lib/src/form_builder.dart
+++ b/packages/flutter_form_builder/lib/src/form_builder.dart
@@ -98,6 +98,9 @@ class FormBuilderState extends State<FormBuilder> {
 
   Map<String, FormBuilderFieldState> get fields => _fields;
 
+  bool get isValid =>
+      fields.values.where((element) => !element.isValid).isEmpty;
+
   void setInternalFieldValue(String name, dynamic value) {
     setState(() => _value[name] = value);
   }


### PR DESCRIPTION
Using the isValid computed property on FormBuilder will enable consumers of the form to check the validity without changing its internal state. I.e. without forcing interaction. Useful to enable/disable submit button.