### PR TITLE
Fix compilation problem of the form_builder_phone_field package example

### DIFF
--- a/packages/form_builder_phone_field/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/form_builder_phone_field/example/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="example"
         android:icon="@mipmap/ic_launcher">
         <activity


### PR DESCRIPTION
This example is using a deprecated version of the Android embedding.
I follow these instructions to fix unexpected runtime failures, or future build failures:
https://flutter.dev/go/android-project-migration
https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects