### PR TITLE
Add a custom filter chip option to accept avatar

### DIFF
--- a/packages/flutter_form_builder/lib/flutter_form_builder.dart
+++ b/packages/flutter_form_builder/lib/flutter_form_builder.dart
@@ -18,4 +18,4 @@ export 'src/fields/form_builder_switch.dart';
 export 'src/fields/form_builder_text_field.dart';
 export 'src/widgets/grouped_checkbox.dart';
 export 'src/widgets/grouped_radio.dart';
-export 'src/options/form_builder_filter_chips_option.dart';
+export 'src/options/form_builder_chip_option.dart';

--- a/packages/flutter_form_builder/lib/flutter_form_builder.dart
+++ b/packages/flutter_form_builder/lib/flutter_form_builder.dart
@@ -18,3 +18,4 @@ export 'src/fields/form_builder_switch.dart';
 export 'src/fields/form_builder_text_field.dart';
 export 'src/widgets/grouped_checkbox.dart';
 export 'src/widgets/grouped_radio.dart';
+export 'src/options/form_builder_filter_chips_option.dart';

--- a/packages/flutter_form_builder/lib/src/fields/form_builder_filter_chips.dart
+++ b/packages/flutter_form_builder/lib/src/fields/form_builder_filter_chips.dart
@@ -12,7 +12,7 @@ class FormBuilderFilterChip<T> extends FormBuilderField<List<T>> {
   final Color? selectedShadowColor;
   final Color? shadowColor;
   final double? elevation, pressElevation;
-  final List<FormBuilderFilterChipsOption<T>> options;
+  final List<FormBuilderChipOption<T>> options;
   final MaterialTapTargetSize? materialTapTargetSize;
   final OutlinedBorder? shape;
 
@@ -102,7 +102,7 @@ class FormBuilderFilterChip<T> extends FormBuilderField<List<T>> {
                 textDirection: textDirection,
                 verticalDirection: verticalDirection,
                 children: <Widget>[
-                  for (FormBuilderFilterChipsOption<T> option in options)
+                  for (FormBuilderChipOption<T> option in options)
                     FilterChip(
                       label: option,
                       selected: field.value!.contains(option.value),

--- a/packages/flutter_form_builder/lib/src/fields/form_builder_filter_chips.dart
+++ b/packages/flutter_form_builder/lib/src/fields/form_builder_filter_chips.dart
@@ -12,7 +12,7 @@ class FormBuilderFilterChip<T> extends FormBuilderField<List<T>> {
   final Color? selectedShadowColor;
   final Color? shadowColor;
   final double? elevation, pressElevation;
-  final List<FormBuilderFieldOption<T>> options;
+  final List<FormBuilderFilterChipsOption<T>> options;
   final MaterialTapTargetSize? materialTapTargetSize;
   final OutlinedBorder? shape;
 
@@ -102,10 +102,11 @@ class FormBuilderFilterChip<T> extends FormBuilderField<List<T>> {
                 textDirection: textDirection,
                 verticalDirection: verticalDirection,
                 children: <Widget>[
-                  for (FormBuilderFieldOption<T> option in options)
+                  for (FormBuilderFilterChipsOption<T> option in options)
                     FilterChip(
                       label: option,
                       selected: field.value!.contains(option.value),
+                      avatar: option.avatar,
                       onSelected: state.enabled &&
                               (null == maxChips ||
                                   field.value!.length < maxChips ||

--- a/packages/flutter_form_builder/lib/src/options/form_builder_chip_option.dart
+++ b/packages/flutter_form_builder/lib/src/options/form_builder_chip_option.dart
@@ -5,11 +5,11 @@ import 'package:flutter_form_builder/flutter_form_builder.dart';
 ///
 /// The type `T` is the type of the value the entry represents. All the entries
 /// in a given menu must represent values with consistent types.
-class FormBuilderFilterChipsOption<T> extends FormBuilderFieldOption<T> {
+class FormBuilderChipOption<T> extends FormBuilderFieldOption<T> {
   final Widget? avatar;
 
   /// Creates an option for fields with selection options
-  const FormBuilderFilterChipsOption({
+  const FormBuilderChipOption({
     Key? key,
     required value,
     this.avatar,

--- a/packages/flutter_form_builder/lib/src/options/form_builder_filter_chips_option.dart
+++ b/packages/flutter_form_builder/lib/src/options/form_builder_filter_chips_option.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+
+/// An option for filter chips.
+///
+/// The type `T` is the type of the value the entry represents. All the entries
+/// in a given menu must represent values with consistent types.
+class FormBuilderFilterChipsOption<T> extends FormBuilderFieldOption<T> {
+  final Widget? avatar;
+
+  /// Creates an option for fields with selection options
+  const FormBuilderFilterChipsOption({
+    Key? key,
+    required value,
+    this.avatar,
+    child,
+  }) : super(
+          key: key,
+          value: value,
+          child: child,
+        );
+
+  @override
+  Widget build(BuildContext context) {
+    return child ?? Text(value.toString());
+  }
+}

--- a/packages/flutter_form_builder/test/form_builder_filter_chips_test.dart
+++ b/packages/flutter_form_builder/test/form_builder_filter_chips_test.dart
@@ -12,9 +12,9 @@ void main() {
       shouldRequestFocus: false,
       name: widgetName,
       options: const [
-        FormBuilderFilterChipsOption(key: ValueKey('1'), value: 1),
-        FormBuilderFilterChipsOption(key: ValueKey('2'), value: 2),
-        FormBuilderFilterChipsOption(key: ValueKey('3'), value: 3),
+        FormBuilderChipOption(key: ValueKey('1'), value: 1),
+        FormBuilderChipOption(key: ValueKey('2'), value: 2),
+        FormBuilderChipOption(key: ValueKey('3'), value: 3),
       ],
     );
     await tester.pumpWidget(buildTestableFieldWidget(testWidget));

--- a/packages/flutter_form_builder/test/form_builder_filter_chips_test.dart
+++ b/packages/flutter_form_builder/test/form_builder_filter_chips_test.dart
@@ -12,9 +12,9 @@ void main() {
       shouldRequestFocus: false,
       name: widgetName,
       options: const [
-        FormBuilderFieldOption(key: ValueKey('1'), value: 1),
-        FormBuilderFieldOption(key: ValueKey('2'), value: 2),
-        FormBuilderFieldOption(key: ValueKey('3'), value: 3),
+        FormBuilderFilterChipsOption(key: ValueKey('1'), value: 1),
+        FormBuilderFilterChipsOption(key: ValueKey('2'), value: 2),
+        FormBuilderFilterChipsOption(key: ValueKey('3'), value: 3),
       ],
     );
     await tester.pumpWidget(buildTestableFieldWidget(testWidget));


### PR DESCRIPTION
This PR will support #1010 .

- Added a custom option `FormBuilderFilterChipsOption`, to pass to `FormBuilderFilterChip` options instead of passing the generic `FormBuilderFieldOption` to it.
- This will give us the ability to pass a custom `Widget? avatar`.