### PR TITLE
FormBuilderRangeSlider don't require initialValue

### DIFF
--- a/packages/flutter_form_builder/lib/src/fields/form_builder_range_slider.dart
+++ b/packages/flutter_form_builder/lib/src/fields/form_builder_range_slider.dart
@@ -110,7 +110,7 @@ class FormBuilderRangeSlider extends FormBuilderField<RangeValues> {
     //From Super
     required String name,
     FormFieldValidator<RangeValues>? validator,
-    required RangeValues initialValue,
+    RangeValues? initialValue,
     InputDecoration decoration = const InputDecoration(),
     ValueChanged<RangeValues?>? onChanged,
     ValueTransformer<RangeValues?>? valueTransformer,


### PR DESCRIPTION
## Connection with issue(s)

Resolve issue #1046 

