### PR TITLE
Remove field values from internal maps when unregistered

### DIFF
--- a/packages/flutter_form_builder/lib/src/form_builder.dart
+++ b/packages/flutter_form_builder/lib/src/form_builder.dart
@@ -63,6 +63,18 @@ class FormBuilder extends StatefulWidget {
   /// Whether the form should auto focus on the first field that fails validation.
   final bool autoFocusOnValidationFailure;
 
+  /// Whether to clear the internal value of a field when it is unregistered.
+  ///
+  /// Defaults to false.
+  ///
+  /// When set to `true`, the form builder will not keep the internal values
+  /// from disposed [FormBuilderField]s. This is useful for dynamic forms where
+  /// fields are registered and unregistered due to state change.
+  ///
+  /// This setting will have no effect due to registering a field with the same
+  /// name as the unregistered one.
+  final bool clearValueOnUnregister;
+
   /// Creates a container for form fields.
   ///
   /// The [child] argument must not be null.
@@ -76,6 +88,7 @@ class FormBuilder extends StatefulWidget {
     this.skipDisabled = false,
     this.enabled = true,
     this.autoFocusOnValidationFailure = false,
+    this.clearValueOnUnregister = false,
   }) : super(key: key);
 
   static FormBuilderState? of(BuildContext context) =>
@@ -186,6 +199,10 @@ class FormBuilderState extends State<FormBuilder> {
     if (field == _fields[name]) {
       _fields.remove(name);
       _transformers.remove(name);
+      if (widget.clearValueOnUnregister) {
+        _instantValue.remove(name);
+        _savedValue.remove(name);
+      }
     } else {
       assert(() {
         // This is OK to ignore when you are intentionally replacing a field
@@ -195,8 +212,6 @@ class FormBuilderState extends State<FormBuilder> {
         return true;
       }());
     }
-    // Removes internal field value
-    // _savedValue.remove(name);
   }
 
   void save() {


### PR DESCRIPTION
I had a problem within one of my projects recently where I had some dynamic fields and removing them would cause a type error when paired with an `onChanged` behaviour, like the one below, because their transformers would be removed from the form but not their input value. I've created an example with the bare minimum to showcase the bug below.

<details><summary>Example code</summary>

```dart
import 'package:flutter/material.dart';
import 'package:flutter_form_builder/flutter_form_builder.dart';

void main() => runApp(const MaterialApp(home: Example()));

class Example extends StatefulWidget {
  const Example({Key? key}) : super(key: key);

  @override
  State<Example> createState() => _ExampleState();
}

class _ExampleState extends State<Example> {
  final formKey = GlobalKey<FormBuilderState>();
  bool showDynamicField = true;

  void onChanged() {
    final dynamicFieldValue = formKey.currentState!.instantValue['dynamic'];

    if (dynamicFieldValue != null) {
      final foo = Foo(dynamicFieldValue);
    }
  }

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: FormBuilder(
        key: formKey,
        onChanged: onChanged,
        child: ListView(
          children: [
            FormBuilderChoiceChip<bool>(
              name: 'name',
              initialValue: true,
              options: const [
                FormBuilderChipOption<bool>(
                  value: true,
                  child: Text('Show dynamic field'),
                ),
              ],
              onChanged: (value) => setState(() {
                showDynamicField = value ?? false;
              }),
            ),
            if (showDynamicField)
              FormBuilderTextField(
                name: 'dynamic',
                valueTransformer: (str) => int.tryParse(str ?? 'null') ?? 0,
              ),
          ],
        ),
      ),
    );
  }
}

class Foo {
  Foo(this.value);
  int value;
}


```
</details>

## Connection with issue(s)

There is no connected issue that I know of because I tried to find a solution myself.

<!-- Required: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request -->

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Testing and Review Notes
<!-- Required: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers -->

For the bug to appear, you should follow these steps:

1. Write an input
2. Hide the dynamic field
3. Show the dynamic field
4. An error should be thrown


## Screenshots or Videos
<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do
<!-- Add “WIP” to the PR title if pushing up but not complete nor ready for review -->
- [ ] double check the original issue to confirm it is fully satisfied
- [ ] add testing notes and screenshots in PR description to help guide reviewers
- [ ] request the "UX" team perform a design review (if/when applicable)

## Final Considerations

In the end I didn't want to change the inherent way the package works but wanted to give options to future users and myself. That's why I approached this by adding another attribute to the `FormBuilder`. And it looks like the behaviour of deleting the field's value was considered at some point by the looks of the comments left on the source code.
```dart
// Removes internal field value
// _savedValue.remove(name);
```
