### PR TITLE
lengthEqual validator added

### DIFF
--- a/packages/form_builder_validators/lib/l10n/intl_en.arb
+++ b/packages/form_builder_validators/lib/l10n/intl_en.arb
@@ -39,6 +39,14 @@
       "maxLength": {}
     }
   },
+  "lengthEqualErrorText": "Value must have a length equal to {length}",
+  "@lengthEqualErrorText": {
+    "description": "Error Text for required field",
+    "type": "text",
+    "placeholders": {
+      "length": {}
+    }
+  },
   "emailErrorText": "This field requires a valid email address.",
   "@emailErrorText": {
     "description": "Error Text for email field",

--- a/packages/form_builder_validators/lib/l10n/intl_messages.arb
+++ b/packages/form_builder_validators/lib/l10n/intl_messages.arb
@@ -54,6 +54,14 @@
       "maxLength": {}
     }
   },
+  "lengthEqualErrorText": "Value must have a length equal to {length}",
+  "@lengthEqualErrorText": {
+    "description": "Error Text for required field",
+    "type": "text",
+    "placeholders": {
+      "length": {}
+    }
+  },
   "emailErrorText": "This field requires a valid email address.",
   "@emailErrorText": {
     "description": "Error Text for email validator",

--- a/packages/form_builder_validators/lib/l10n/intl_tr.arb
+++ b/packages/form_builder_validators/lib/l10n/intl_tr.arb
@@ -39,6 +39,14 @@
       "maxLength": {}
     }
   },
+  "lengthEqualErrorText": "Değerin uzunluğu {length} değerine eşit olmalıdır.",
+  "@lengthEqualErrorText": {
+    "description": "Error Text for required field",
+    "type": "text",
+    "placeholders": {
+      "length": {}
+    }
+  },
   "emailErrorText": "Bu alan geçerli bir e-posta adresi gerektirir.",
   "@emailErrorText": {
     "description": "Error Text for email field",

--- a/packages/form_builder_validators/lib/localization/intl/messages_en.dart
+++ b/packages/form_builder_validators/lib/localization/intl/messages_en.dart
@@ -22,6 +22,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m0(value) => "This field value must be equal to ${value}.";
 
+  static String m6(length) => "Value must have a length equal to ${length}";
+
   static String m1(max) => "Value must be less than or equal to ${max}";
 
   static String m2(maxLength) =>
@@ -47,6 +49,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "This field requires a valid integer."),
         "ipErrorText": MessageLookupByLibrary.simpleMessage(
             "This field requires a valid IP."),
+        "lengthEqualErrorText": m6,
         "matchErrorText": MessageLookupByLibrary.simpleMessage(
             "Value does not match pattern."),
         "maxErrorText": m1,

--- a/packages/form_builder_validators/lib/localization/intl/messages_messages.dart
+++ b/packages/form_builder_validators/lib/localization/intl/messages_messages.dart
@@ -22,6 +22,8 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m0(value) => "This field value must be equal to ${value}.";
 
+  static String m6(length) => "Value must have a length equal to ${length}";
+
   static String m1(max) => "Value must be less than or equal to ${max}";
 
   static String m2(maxLength) =>
@@ -47,6 +49,7 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Value must be an integer."),
         "ipErrorText": MessageLookupByLibrary.simpleMessage(
             "This field requires a valid IP."),
+        "lengthEqualErrorText": m6,
         "matchErrorText": MessageLookupByLibrary.simpleMessage(
             "Value does not match pattern."),
         "maxErrorText": m1,

--- a/packages/form_builder_validators/lib/localization/intl/messages_tr.dart
+++ b/packages/form_builder_validators/lib/localization/intl/messages_tr.dart
@@ -23,6 +23,9 @@ class MessageLookup extends MessageLookupByLibrary {
   static String m0(value) =>
       "Bu alanın değeri, {değer} değerine eşit olmalıdır.";
 
+  static String m6(length) =>
+      "Değerin uzunluğu ${length} değerine eşit olmalıdır.";
+
   static String m1(max) => "Değer ${max} değerinden küçük veya eşit olmalıdır.";
 
   static String m2(maxLength) =>
@@ -49,6 +52,7 @@ class MessageLookup extends MessageLookupByLibrary {
             "Bu alan geçerli bir tamsayı gerektirir."),
         "ipErrorText": MessageLookupByLibrary.simpleMessage(
             "Bu alan geçerli bir IP adresi gerektirir."),
+        "lengthEqualErrorText": m6,
         "matchErrorText": MessageLookupByLibrary.simpleMessage(
             "Lütfen geçerli bir değer giriniz."),
         "maxErrorText": m1,

--- a/packages/form_builder_validators/lib/localization/l10n.dart
+++ b/packages/form_builder_validators/lib/localization/l10n.dart
@@ -101,6 +101,16 @@ class FormBuilderLocalizations {
     );
   }
 
+  /// `Value must have a length equal to {length}`
+  String lengthEqualErrorText(Object length) {
+    return Intl.message(
+      'Value must have a length equal to $length',
+      name: 'lengthEqualErrorText',
+      desc: 'Error Text for required field',
+      args: [length],
+    );
+  }
+
   /// `This field requires a valid email address.`
   String get emailErrorText {
     return Intl.message(

--- a/packages/form_builder_validators/lib/src/form_builder_validators.dart
+++ b/packages/form_builder_validators/lib/src/form_builder_validators.dart
@@ -158,9 +158,11 @@ class FormBuilderValidators {
           valueCandidate is Iterable ||
           valueCandidate == null);
       var valueLength = 0;
+
       if (valueCandidate is String) valueLength = valueCandidate.length;
       if (valueCandidate is Iterable) valueLength = valueCandidate.length;
-      return null != valueCandidate && valueLength != length
+
+      return valueLength != length
           ? errorText ??
               FormBuilderLocalizations.current.lengthEqualErrorText(length)
           : null;

--- a/packages/form_builder_validators/lib/src/form_builder_validators.dart
+++ b/packages/form_builder_validators/lib/src/form_builder_validators.dart
@@ -146,7 +146,7 @@ class FormBuilderValidators {
     };
   }
 
-  /// [FormFieldValidator] that requires the length of the field's string value length to be
+  /// [FormFieldValidator] that requires the length of the field to be
   /// equal to the provided length. Works with String and Iterable types.
   static FormFieldValidator<T> lengthEqual<T>(
     int length, {

--- a/packages/form_builder_validators/lib/src/form_builder_validators.dart
+++ b/packages/form_builder_validators/lib/src/form_builder_validators.dart
@@ -147,7 +147,7 @@ class FormBuilderValidators {
   }
 
   /// [FormFieldValidator] that requires the length of the field to be
-  /// equal to the provided length.
+  /// equal to the provided length. Works with String, iterable and int types
   static FormFieldValidator<T> lengthEqual<T>(
     int length, {
     String? errorText,

--- a/packages/form_builder_validators/lib/src/form_builder_validators.dart
+++ b/packages/form_builder_validators/lib/src/form_builder_validators.dart
@@ -156,9 +156,11 @@ class FormBuilderValidators {
     return (T? valueCandidate) {
       assert(valueCandidate is String ||
           valueCandidate is Iterable ||
+          valueCandidate is int ||
           valueCandidate == null);
       var valueLength = 0;
 
+      if (valueCandidate is int) valueLength = valueCandidate.toString().length;
       if (valueCandidate is String) valueLength = valueCandidate.length;
       if (valueCandidate is Iterable) valueLength = valueCandidate.length;
 

--- a/packages/form_builder_validators/lib/src/form_builder_validators.dart
+++ b/packages/form_builder_validators/lib/src/form_builder_validators.dart
@@ -147,7 +147,7 @@ class FormBuilderValidators {
   }
 
   /// [FormFieldValidator] that requires the length of the field to be
-  /// equal to the provided length. Works with String and Iterable types.
+  /// equal to the provided length.
   static FormFieldValidator<T> lengthEqual<T>(
     int length, {
     String? errorText,

--- a/packages/form_builder_validators/lib/src/form_builder_validators.dart
+++ b/packages/form_builder_validators/lib/src/form_builder_validators.dart
@@ -136,7 +136,7 @@ class FormBuilderValidators {
       assert(valueCandidate is String ||
           valueCandidate is Iterable ||
           valueCandidate == null);
-      var valueLength = 0;
+      int valueLength = 0;
       if (valueCandidate is String) valueLength = valueCandidate.length;
       if (valueCandidate is Iterable) valueLength = valueCandidate.length;
       return null != valueCandidate && valueLength > maxLength

--- a/packages/form_builder_validators/lib/src/form_builder_validators.dart
+++ b/packages/form_builder_validators/lib/src/form_builder_validators.dart
@@ -146,8 +146,8 @@ class FormBuilderValidators {
     };
   }
 
-  /// [FormFieldValidator] that requires the length of the field's value to be
-  /// equal to the provided length.
+  /// [FormFieldValidator] that requires the length of the field's string value length to be
+  /// equal to the provided length. Works with String and Iterable types.
   static FormFieldValidator<T> lengthEqual<T>(
     int length, {
     String? errorText,

--- a/packages/form_builder_validators/lib/src/form_builder_validators.dart
+++ b/packages/form_builder_validators/lib/src/form_builder_validators.dart
@@ -146,6 +146,27 @@ class FormBuilderValidators {
     };
   }
 
+  /// [FormFieldValidator] that requires the length of the field's value to be
+  /// equal to the provided length.
+  static FormFieldValidator<T> lengthEqual<T>(
+    int length, {
+    String? errorText,
+  }) {
+    assert(length > 0);
+    return (T? valueCandidate) {
+      assert(valueCandidate is String ||
+          valueCandidate is Iterable ||
+          valueCandidate == null);
+      var valueLength = 0;
+      if (valueCandidate is String) valueLength = valueCandidate.length;
+      if (valueCandidate is Iterable) valueLength = valueCandidate.length;
+      return null != valueCandidate && valueLength != length
+          ? errorText ??
+              FormBuilderLocalizations.current.lengthEqualErrorText(length)
+          : null;
+    };
+  }
+
   /// [FormFieldValidator] that requires the field's value to be a valid email address.
   static FormFieldValidator<String> email({
     String? errorText,

--- a/packages/form_builder_validators/test/form_builder_validators_test.dart
+++ b/packages/form_builder_validators/test/form_builder_validators_test.dart
@@ -193,6 +193,22 @@ void main() {
           }));
 
   testWidgets(
+      'FormBuilderValidators.lengthEqual for int',
+      (WidgetTester tester) => testValidations(tester, (context) {
+            final validator = FormBuilderValidators.lengthEqual<int>(3);
+
+            // Pass
+            expect(validator(333), isNull);
+
+            // Fail
+            expect(validator(null), isNotNull);
+            expect(validator(0), isNotNull);
+            expect(validator(1), isNotNull);
+            expect(validator(22), isNotNull);
+            expect(validator(4444), isNotNull);
+          }));
+
+  testWidgets(
       'FormBuilderValidators.email',
       (WidgetTester tester) => testValidations(tester, (context) {
             final validator = FormBuilderValidators.email();

--- a/packages/form_builder_validators/test/form_builder_validators_test.dart
+++ b/packages/form_builder_validators/test/form_builder_validators_test.dart
@@ -163,17 +163,16 @@ void main() {
             expect(validatorAllowEmpty([]), isNull);
           }));
   testWidgets(
-      'FormBuilderValidators.lengthEqual for Iterable',
+      'FormBuilderValidators.lengthEqual for String',
       (WidgetTester tester) => testValidations(tester, (context) {
-            final validator =
-                FormBuilderValidators.lengthEqual<Iterable<String>>(3);
+            final validator = FormBuilderValidators.lengthEqual<String>(3);
             // Pass
-            expect(validator(['one', 'two', 'three']), isNull);
+            expect(validator("one"), isNull);
 
             // Fail
             expect(validator(null), isNotNull);
-            expect(validator([]), isNotNull);
-            expect(validator(['one', 'two']), isNotNull);
+            expect(validator(""), isNotNull);
+            expect(validator("three"), isNotNull);
           }));
 
   testWidgets(

--- a/packages/form_builder_validators/test/form_builder_validators_test.dart
+++ b/packages/form_builder_validators/test/form_builder_validators_test.dart
@@ -163,16 +163,33 @@ void main() {
             expect(validatorAllowEmpty([]), isNull);
           }));
   testWidgets(
+      'FormBuilderValidators.lengthEqual for Iterable',
+      (WidgetTester tester) => testValidations(tester, (context) {
+            final validator =
+                FormBuilderValidators.lengthEqual<Iterable<String>>(3);
+
+            // Pass
+            expect(validator(["a", "b", "c"]), isNull);
+
+            // Fail
+            expect(validator(null), isNotNull);
+            expect(validator([]), isNotNull);
+            expect(validator(['one', 'two']), isNotNull);
+            expect(validator(['one', 'two', 'three', 'four']), isNotNull);
+          }));
+  testWidgets(
       'FormBuilderValidators.lengthEqual for String',
       (WidgetTester tester) => testValidations(tester, (context) {
             final validator = FormBuilderValidators.lengthEqual<String>(3);
+
             // Pass
-            expect(validator("one"), isNull);
+            expect(validator("333"), isNull);
 
             // Fail
             expect(validator(null), isNotNull);
             expect(validator(""), isNotNull);
-            expect(validator("three"), isNotNull);
+            expect(validator("22"), isNotNull);
+            expect(validator("4444"), isNotNull);
           }));
 
   testWidgets(

--- a/packages/form_builder_validators/test/form_builder_validators_test.dart
+++ b/packages/form_builder_validators/test/form_builder_validators_test.dart
@@ -162,6 +162,19 @@ void main() {
             expect(validatorAllowEmpty(null), isNull);
             expect(validatorAllowEmpty([]), isNull);
           }));
+  testWidgets(
+      'FormBuilderValidators.lengthEqual for Iterable',
+      (WidgetTester tester) => testValidations(tester, (context) {
+            final validator =
+                FormBuilderValidators.lengthEqual<Iterable<String>>(3);
+            // Pass
+            expect(validator(['one', 'two', 'three']), isNull);
+
+            // Fail
+            expect(validator(null), isNotNull);
+            expect(validator([]), isNotNull);
+            expect(validator(['one', 'two']), isNotNull);
+          }));
 
   testWidgets(
       'FormBuilderValidators.email',


### PR DESCRIPTION
Closes https://github.com/danvick/flutter_form_builder/issues/757

lengthEqual validator added.

lengthEqual supported types for validation String, int and Iterable. 

My branch include 3 test for this validator.

lengthEqual for String
lengthEqual for Iterable
lengthEqual for int
