### PR TITLE
feat: allow the date picker dialog to be opened programmatically (closes #1477)

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -91,18 +91,18 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.19.0"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -224,10 +224,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "14.3.1"
 sdks:
   dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.29.0"

--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -124,6 +124,8 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
   final bool barrierDismissible;
 
   /// Creates field for `Date`, `Time` and `DateTime` input
+  ///
+  /// The picker can be programmatically opened using the [showPicker] method.
   FormBuilderDateTimePicker({
     super.key,
     required super.name,
@@ -194,7 +196,7 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
     this.barrierDismissible = true,
   }) : super(
          builder: (FormFieldState<DateTime?> field) {
-           final state = field as _FormBuilderDateTimePickerState;
+           final state = field as FormBuilderDateTimePickerState;
 
            return FocusTraversalGroup(
              policy: ReadingOrderTraversalPolicy(),
@@ -239,10 +241,10 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
 
   @override
   FormBuilderFieldDecorationState<FormBuilderDateTimePicker, DateTime>
-  createState() => _FormBuilderDateTimePickerState();
+  createState() => FormBuilderDateTimePickerState();
 }
 
-class _FormBuilderDateTimePickerState
+class FormBuilderDateTimePickerState
     extends
         FormBuilderFieldDecorationState<FormBuilderDateTimePicker, DateTime> {
   late TextEditingController _textFieldController;

--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -124,8 +124,6 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
   final bool barrierDismissible;
 
   /// Creates field for `Date`, `Time` and `DateTime` input
-  ///
-  /// The picker can be programmatically opened using the [showPicker] method.
   FormBuilderDateTimePicker({
     super.key,
     required super.name,
@@ -244,6 +242,9 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
   createState() => FormBuilderDateTimePickerState();
 }
 
+/// Holds the state of a [FormBuilderDateTimePicker].
+///
+/// The picker can be programmatically opened using the [showPicker] method.
 class FormBuilderDateTimePickerState
     extends
         FormBuilderFieldDecorationState<FormBuilderDateTimePicker, DateTime> {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -79,10 +79,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -204,10 +204,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "14.3.1"
 sdks:
   dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.29.0"


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #1477 

## Solution description
Making `FormBuilderDateTimePickerState` public allows calling the `showPicker` method programatically.
We can access it like so:
```dart
final dateTimePickerKey = GlobalKey<FormBuilderDateTimePickerState>();
...
FormBuilderDateTimePicker(key: dateTimePickerKey),
...
dateTimePickerKey.currentState?.showPicker();
```

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
