### PR TITLE
feat: #1311 add allowClear and clearIcon to FormBuilderDateTimePicker

### DIFF
--- a/example/lib/sources/complete_form.dart
+++ b/example/lib/sources/complete_form.dart
@@ -55,15 +55,17 @@ class _CompleteFormState extends State<CompleteForm> {
                   inputType: InputType.both,
                   decoration: InputDecoration(
                     labelText: 'Appointment Time',
-                    suffixIcon: IconButton(
-                      icon: const Icon(Icons.close),
-                      onPressed: () {
-                        _formKey.currentState!.fields['date']?.didChange(null);
-                      },
-                    ),
+                    // suffixIcon: IconButton(
+                    //   icon: const Icon(Icons.close),
+                    //   onPressed: () {
+                    //     _formKey.currentState!.fields['date']?.didChange(null);
+                    //   },
+                    // ),
                   ),
                   initialTime: const TimeOfDay(hour: 8, minute: 0),
                   // locale: const Locale.fromSubtags(languageCode: 'fr'),
+                  allowClear: true,
+                  clearIcon: Icon(Icons.clear),
                 ),
                 FormBuilderDateRangePicker(
                   name: 'date_range',

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -60,7 +60,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "10.3.0+1"
+    version: "10.3.0+2"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -131,10 +131,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -208,10 +208,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -2,10 +2,8 @@ import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-
-import 'package:intl/intl.dart';
-
 import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:intl/intl.dart';
 
 enum InputType { date, time, both }
 
@@ -123,6 +121,9 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
   final EntryModeChangeCallback? onEntryModeChanged;
   final bool barrierDismissible;
 
+  final bool allowClear;
+  final Widget? clearIcon;
+
   /// If true, disables the picker so it's not shown when the field is tapped.
   final bool disablePicker;
 
@@ -197,6 +198,9 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
     this.onEntryModeChanged,
     this.disablePicker = false,
     this.barrierDismissible = true,
+    // TODO: set allClear to true if that's the default behaviour
+    this.allowClear = false,
+    this.clearIcon,
   }) : super(
          builder: (FormFieldState<DateTime?> field) {
            final state = field as _FormBuilderDateTimePickerState;
@@ -403,6 +407,27 @@ class _FormBuilderDateTimePickerState
 
   DateTime? convert(TimeOfDay? time) =>
       time == null ? null : DateTime(1, 1, 1, time.hour, time.minute);
+
+  /// Sets the [allowClear] property for automatic DateTime reset, and [clearIcon] to a default or user defined icon.
+  @override
+  InputDecoration get decoration => widget.allowClear
+      ? super.decoration.copyWith(
+          suffix: value == null
+              ? null
+              : IconButton(
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(
+                    maxWidth: 24,
+                    maxHeight: 24,
+                  ),
+                  onPressed: () {
+                    focus();
+                    didChange(null);
+                  },
+                  icon: widget.clearIcon ?? const Icon(Icons.clear),
+                ),
+        )
+      : super.decoration;
 
   @override
   void didChange(DateTime? value) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -111,10 +111,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -188,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:

--- a/test/src/fields/form_builder_date_time_picker_test.dart
+++ b/test/src/fields/form_builder_date_time_picker_test.dart
@@ -197,6 +197,194 @@ void main() {
         );
       });
     });
+
+    testWidgets('allowClear properly clears value', (
+      WidgetTester tester,
+    ) async {
+      const widgetName = 'fdtp_clear';
+      final widgetKey = UniqueKey();
+      final initialDate = DateTime(2023, 1, 1);
+
+      final testWidget = FormBuilderDateTimePicker(
+        key: widgetKey,
+        name: widgetName,
+        initialValue: initialDate,
+        allowClear: true,
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+      expect(formInstantValue(widgetName), initialDate);
+      expect(find.byIcon(Icons.clear), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.clear));
+      await tester.pumpAndSettle();
+
+      expect(formInstantValue(widgetName), isNull);
+      expect(find.byIcon(Icons.clear), findsNothing);
+    });
+
+    testWidgets('custom clearIcon is rendered', (WidgetTester tester) async {
+      const widgetName = 'fdtp_custom_clear';
+      final initialDate = DateTime(2023, 1, 1);
+      const customIcon = Icons.delete;
+
+      final testWidget = FormBuilderDateTimePicker(
+        name: widgetName,
+        initialValue: initialDate,
+        allowClear: true,
+        clearIcon: const Icon(customIcon),
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+      expect(find.byIcon(customIcon), findsOneWidget);
+      expect(find.byIcon(Icons.clear), findsNothing);
+    });
+
+    testWidgets('InputType.date returns midnight time', (
+      WidgetTester tester,
+    ) async {
+      const widgetName = 'fdtp_date_only';
+      final widgetKey = UniqueKey();
+      final dateNow = DateTime.now();
+      const confirmText = 'OK';
+
+      final testWidget = FormBuilderDateTimePicker(
+        key: widgetKey,
+        name: widgetName,
+        inputType: InputType.date,
+        confirmText: confirmText,
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+      await tester.tap(find.byKey(widgetKey));
+      await tester.pumpAndSettle();
+
+      final testDay = dateNow.day - 1 <= 0 ? dateNow.day + 1 : dateNow.day - 1;
+      await tester.tap(find.text(testDay.toString()));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(confirmText));
+      await tester.pumpAndSettle();
+
+      expect(formSave(), isTrue);
+      expect(
+        formValue<DateTime>(widgetName),
+        DateTime(dateNow.year, dateNow.month, testDay),
+      );
+    });
+
+    testWidgets('InputType.time returns DateTime(1, 1, 1) with time', (
+      WidgetTester tester,
+    ) async {
+      const widgetName = 'fdtp_time_only';
+      final widgetKey = UniqueKey();
+      const confirmText = 'OK';
+
+      final testWidget = FormBuilderDateTimePicker(
+        key: widgetKey,
+        name: widgetName,
+        inputType: InputType.time,
+        confirmText: confirmText,
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+      await tester.tap(find.byKey(widgetKey));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text(confirmText));
+      await tester.pumpAndSettle();
+
+      expect(formSave(), isTrue);
+      final value = formValue<DateTime>(widgetName);
+      expect(value.year, 1);
+      expect(value.month, 1);
+      expect(value.day, 1);
+      expect(value.hour, 12); // Default initialTime is 12:00
+      expect(value.minute, 0);
+    });
+
+    testWidgets('onChanged is called when value changes', (
+      WidgetTester tester,
+    ) async {
+      const widgetName = 'fdtp_onChanged';
+      int changedCount = 0;
+      DateTime? valueFromOnChanged;
+
+      final testWidget = FormBuilderDateTimePicker(
+        name: widgetName,
+        allowClear: true,
+        initialValue: DateTime(2023, 1, 1),
+        onChanged: (val) {
+          changedCount++;
+          valueFromOnChanged = val;
+        },
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+      await tester.tap(find.byIcon(Icons.clear));
+      await tester.pumpAndSettle();
+
+      expect(changedCount, 1);
+      expect(valueFromOnChanged, isNull);
+    });
+
+    testWidgets('reset() reverts value to initialValue', (
+      WidgetTester tester,
+    ) async {
+      const widgetName = 'fdtp_reset';
+      final initialDate = DateTime(2023, 1, 1);
+
+      final testWidget = FormBuilderDateTimePicker(
+        name: widgetName,
+        initialValue: initialDate,
+        allowClear: true,
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+      await tester.tap(find.byIcon(Icons.clear));
+      await tester.pumpAndSettle();
+      expect(formInstantValue(widgetName), isNull);
+
+      formKey.currentState!.fields[widgetName]!.reset();
+      await tester.pumpAndSettle();
+
+      expect(formInstantValue(widgetName), initialDate);
+    });
+
+    testWidgets('initialTime is respected for InputType.both', (
+      WidgetTester tester,
+    ) async {
+      const widgetName = 'fdtp_initialTime';
+      final widgetKey = UniqueKey();
+      const confirmText = 'OK';
+      final initialTime = const TimeOfDay(hour: 15, minute: 30);
+
+      final testWidget = FormBuilderDateTimePicker(
+        key: widgetKey,
+        name: widgetName,
+        inputType: InputType.both,
+        confirmText: confirmText,
+        initialTime: initialTime,
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+      await tester.tap(find.byKey(widgetKey));
+      await tester.pumpAndSettle();
+
+      // Date picker OK
+      await tester.tap(find.text(DateTime.now().day.toString()));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text(confirmText));
+      await tester.pumpAndSettle();
+
+      // Time picker should show 15:30.
+      await tester.tap(find.text(confirmText));
+      await tester.pumpAndSettle();
+
+      expect(formSave(), isTrue);
+      final value = formValue<DateTime>(widgetName);
+      expect(value.hour, 15);
+      expect(value.minute, 30);
+    });
   });
 
   testWidgets('When press tab, field will be focused', (


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #1311

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Solution description

Added `allowClear` property to `FormBuilderDateTimePicker` also builds upon the default input decoration.

```dart
@override
InputDecoration get decoration => widget.allowClear
    ? super.decoration.copyWith(
        suffix: value == null
            ? null
            : IconButton(
                padding: EdgeInsets.zero,
                constraints: const BoxConstraints(
                  maxWidth: 24,
                  maxHeight: 24,
                ),
                onPressed: () {
                  focus();
                  didChange(null);
                },
                icon: widget.clearIcon ?? const Icon(Icons.clear),
              ),
      )
    : super.decoration;
```

To use the new property

```dart
FormBuilderDateTimePicker(
  name: 'date',
  initialEntryMode: DatePickerEntryMode.calendar,
  initialValue: DateTime.now(),
  inputType: InputType.both,
  decoration: InputDecoration(
    labelText: 'Appointment Time',
    // TODO: use allowClear property to automatically perform this action.
    // suffixIcon: IconButton(
    //   icon: const Icon(Icons.close),
    //   onPressed: () {
    //     _formKey.currentState!.fields['date']?.didChange(null);
    //   },
    // ),
  ),
  initialTime: const TimeOfDay(hour: 8, minute: 0),
  // locale: const Locale.fromSubtags(languageCode: 'fr'),
  allowClear: true,
  // TODO: use any icon of choice or default one
  clearIcon: Icon(Icons.clear),
)
```

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

<img width="468" height="288" alt="Screenshot 2026-04-14 144529" src="https://github.com/user-attachments/assets/3c995ba1-73b3-4827-b5ea-49b4053dc89e" />

*As you can see the `x` icon doesn't appear when the field is empty*

<img width="468" height="303" alt="image" src="https://github.com/user-attachments/assets/e3ddd894-c517-4921-846e-f253c0d3a6a7" />

*The `x` icon appears ONLY when date and time are both selected, and also not selecting time leads to empty value in the field*

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
