### PR TITLE
fix: #1484 autoValidateMode breaks invalidate method

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -60,7 +60,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "10.3.0+1"
+    version: "10.3.0+2"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -131,10 +131,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -208,10 +208,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:

--- a/lib/src/fields/form_builder_checkbox.dart
+++ b/lib/src/fields/form_builder_checkbox.dart
@@ -107,6 +107,7 @@ class FormBuilderCheckbox extends FormBuilderFieldDecoration<bool> {
     super.focusNode,
     super.restorationId,
     super.errorBuilder,
+    super.forceErrorText,
     required this.title,
     this.activeColor,
     this.autofocus = false,

--- a/lib/src/fields/form_builder_checkbox_group.dart
+++ b/lib/src/fields/form_builder_checkbox_group.dart
@@ -46,6 +46,7 @@ class FormBuilderCheckboxGroup<T> extends FormBuilderFieldDecoration<List<T>> {
     super.focusNode,
     super.restorationId,
     super.errorBuilder,
+    super.forceErrorText,
     required this.options,
     this.activeColor,
     this.checkColor,

--- a/lib/src/fields/form_builder_choice_chips.dart
+++ b/lib/src/fields/form_builder_choice_chips.dart
@@ -353,6 +353,7 @@ class FormBuilderChoiceChips<T> extends FormBuilderFieldDecoration<T> {
     super.decoration,
     super.key,
     required super.name,
+    super.forceErrorText,
     required this.options,
     super.initialValue,
     super.restorationId,

--- a/lib/src/fields/form_builder_text_field.dart
+++ b/lib/src/fields/form_builder_text_field.dart
@@ -378,6 +378,7 @@ class FormBuilderTextField extends FormBuilderFieldDecoration<String> {
     super.onReset,
     super.focusNode,
     super.restorationId,
+    super.forceErrorText,
     String? initialValue,
     super.errorBuilder,
     this.readOnly = false,

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -52,6 +52,7 @@ class FormBuilderField<T> extends FormField<T> {
     required super.builder,
     super.errorBuilder,
     super.onReset,
+    super.forceErrorText,
     required this.name,
     this.valueTransformer,
     this.onChanged,
@@ -210,6 +211,9 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   @override
   void didChange(T? value) {
     super.didChange(value);
+    if (_customErrorText != null) {
+      setState(() => _customErrorText = null);
+    }
     _informFormForFieldChange();
     widget.onChanged?.call(value);
   }
@@ -230,7 +234,7 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   /// Validate field
   ///
   /// Clear custom error if [clearCustomError] is `true`.
-  /// By default `true`
+  /// By default `false`
   ///
   /// Focus when field is invalid if [focusOnInvalid] is `true`.
   /// By default `true`
@@ -244,7 +248,7 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   /// not because [autoScrollWhenFocusOnInvalid] is `true`.
   @override
   bool validate({
-    bool clearCustomError = true,
+    bool clearCustomError = false,
     bool focusOnInvalid = true,
     bool autoScrollWhenFocusOnInvalid = false,
   }) {

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -233,6 +233,11 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
 
   /// Validate field
   ///
+  /// **BREAKING CHANGE**:
+  /// In previous versions, calling `validate()` would automatically clear any custom errors set via `invalidate()`.
+  /// Now, `validate()` does not clear custom errors by default.
+  /// If you want to clear the custom error when validating, you must explicitly pass `clearCustomError: true`.
+  ///
   /// Clear custom error if [clearCustomError] is `true`.
   /// By default `false`
   ///

--- a/lib/src/form_builder_field_decoration.dart
+++ b/lib/src/form_builder_field_decoration.dart
@@ -20,6 +20,7 @@ class FormBuilderFieldDecoration<T> extends FormBuilderField<T> {
     super.onReset,
     super.focusNode,
     super.errorBuilder,
+    super.forceErrorText,
     required super.builder,
     this.decoration = const InputDecoration(),
   }) : assert(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -111,10 +111,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -188,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:

--- a/test/src/fields/form_builder_text_field_test.dart
+++ b/test/src/fields/form_builder_text_field_test.dart
@@ -66,7 +66,9 @@ void main() {
       expect(Focus.of(tester.element(widgetFinder)).hasFocus, true);
       expect(focusNode?.hasFocus, true);
     });
-    testWidgets('forceErrorText should show error', (WidgetTester tester) async {
+    testWidgets('forceErrorText should show error', (
+      WidgetTester tester,
+    ) async {
       const errorText = 'Force error message';
       const textFieldName = 'text1';
       final testWidget = FormBuilderTextField(

--- a/test/src/fields/form_builder_text_field_test.dart
+++ b/test/src/fields/form_builder_text_field_test.dart
@@ -66,6 +66,18 @@ void main() {
       expect(Focus.of(tester.element(widgetFinder)).hasFocus, true);
       expect(focusNode?.hasFocus, true);
     });
+    testWidgets('forceErrorText should show error', (WidgetTester tester) async {
+      const errorText = 'Force error message';
+      const textFieldName = 'text1';
+      final testWidget = FormBuilderTextField(
+        name: textFieldName,
+        forceErrorText: errorText,
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+      await tester.pumpAndSettle();
+
+      expect(find.text(errorText), findsOneWidget);
+    });
   });
 }
 

--- a/test/src/form_builder_field_test.dart
+++ b/test/src/form_builder_field_test.dart
@@ -562,23 +562,24 @@ void main() {
         expect(find.text(errorText), findsOneWidget);
       });
 
-      testWidgets('Should override validator error when forceErrorText is set', (
-        tester,
-      ) async {
-        const forceError = 'Force error';
-        const validatorError = 'Validator error';
-        final testWidget = FormBuilderTextField(
-          name: 'text',
-          forceErrorText: forceError,
-          validator: (value) => validatorError,
-          autovalidateMode: AutovalidateMode.always,
-        );
-        await tester.pumpWidget(buildTestableFieldWidget(testWidget));
-        await tester.pumpAndSettle();
+      testWidgets(
+        'Should override validator error when forceErrorText is set',
+        (tester) async {
+          const forceError = 'Force error';
+          const validatorError = 'Validator error';
+          final testWidget = FormBuilderTextField(
+            name: 'text',
+            forceErrorText: forceError,
+            validator: (value) => validatorError,
+            autovalidateMode: AutovalidateMode.always,
+          );
+          await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+          await tester.pumpAndSettle();
 
-        expect(find.text(forceError), findsOneWidget);
-        expect(find.text(validatorError), findsNothing);
-      });
+          expect(find.text(forceError), findsOneWidget);
+          expect(find.text(validatorError), findsNothing);
+        },
+      );
     });
   });
 }

--- a/test/src/form_builder_field_test.dart
+++ b/test/src/form_builder_field_test.dart
@@ -25,6 +25,37 @@ void main() {
         await tester.pumpAndSettle();
         expect(find.text(errorTextField), findsOneWidget);
       });
+      testWidgets(
+        'Should persist custom error when autovalidateMode is onUserInteraction',
+        (tester) async {
+          final textFieldKey = GlobalKey<FormBuilderFieldState>();
+          const textFieldName = 'text';
+          const errorTextField = 'custom error';
+          final testWidget = FormBuilderTextField(
+            name: textFieldName,
+            key: textFieldKey,
+            autovalidateMode: AutovalidateMode.onUserInteraction,
+          );
+          await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+          // Set custom error
+          textFieldKey.currentState?.invalidate(errorTextField);
+          await tester.pumpAndSettle();
+          expect(find.text(errorTextField), findsOneWidget);
+
+          // Simulate framework call (e.g. build again)
+          tester.binding.scheduleFrame();
+          await tester.pumpAndSettle();
+
+          // Should still be there
+          expect(find.text(errorTextField), findsOneWidget);
+
+          // Should clear when value changes
+          await tester.enterText(find.byType(TextField), 'test');
+          await tester.pumpAndSettle();
+          expect(find.text(errorTextField), findsNothing);
+        },
+      );
     });
 
     group('isValid -', () {
@@ -515,6 +546,39 @@ void main() {
           expect(focusNode?.hasFocus, false);
         },
       );
+    });
+    group('forceErrorText -', () {
+      testWidgets('Should show error when forceErrorText is set', (
+        tester,
+      ) async {
+        const errorText = 'Force error message';
+        final testWidget = FormBuilderTextField(
+          name: 'text',
+          forceErrorText: errorText,
+        );
+        await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+        await tester.pumpAndSettle();
+
+        expect(find.text(errorText), findsOneWidget);
+      });
+
+      testWidgets('Should override validator error when forceErrorText is set', (
+        tester,
+      ) async {
+        const forceError = 'Force error';
+        const validatorError = 'Validator error';
+        final testWidget = FormBuilderTextField(
+          name: 'text',
+          forceErrorText: forceError,
+          validator: (value) => validatorError,
+          autovalidateMode: AutovalidateMode.always,
+        );
+        await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+        await tester.pumpAndSettle();
+
+        expect(find.text(forceError), findsOneWidget);
+        expect(find.text(validatorError), findsNothing);
+      });
     });
   });
 }

--- a/test/src/form_builder_field_test.dart
+++ b/test/src/form_builder_field_test.dart
@@ -58,6 +58,46 @@ void main() {
       );
     });
 
+    group('transformedValue -', () {
+      testWidgets('Should return raw value when valueTransformer is null', (
+        tester,
+      ) async {
+        final textFieldKey = GlobalKey<FormBuilderFieldState>();
+        const textFieldName = 'text';
+        final testWidget = FormBuilderTextField(
+          name: textFieldName,
+          key: textFieldKey,
+        );
+        await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+        final widgetFinder = find.byWidget(testWidget);
+        await tester.enterText(widgetFinder, '123');
+        await tester.pumpAndSettle();
+
+        expect(textFieldKey.currentState?.transformedValue, '123');
+      });
+
+      testWidgets(
+        'Should return transformed value when valueTransformer is provided',
+        (tester) async {
+          final textFieldKey = GlobalKey<FormBuilderFieldState>();
+          const textFieldName = 'text';
+          final testWidget = FormBuilderTextField(
+            name: textFieldName,
+            key: textFieldKey,
+            valueTransformer: (text) => int.tryParse(text ?? ''),
+          );
+          await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+          final widgetFinder = find.byWidget(testWidget);
+          await tester.enterText(widgetFinder, '123');
+          await tester.pumpAndSettle();
+
+          expect(textFieldKey.currentState?.transformedValue, 123);
+        },
+      );
+    });
+
     group('isValid -', () {
       testWidgets('Should invalid when set custom error', (tester) async {
         final textFieldKey = GlobalKey<FormBuilderFieldState>();


### PR DESCRIPTION
## Connection with issue(s)

Close #1484
Close #1485

## Solution description

Fixes an issue where `invalidate()` calls were being cleared by framework validation when `autovalidateMode` was active. It also introduces support for the new Flutter `forceErrorText` property across the core library.

### Key Changes:
1.  **`FormBuilderFieldState` Persistence Logic**:
    *   Changed the default value of `clearCustomError` in `validate()` from `true` to `false`. This prevents framework-triggered validation calls (which pass no arguments) from clearing manual errors.
    *   Updated `didChange()` to explicitly clear `_customErrorText`. This ensures that manual errors are removed as soon as the user interacts with the field, maintaining a logical UX.
2.  **`forceErrorText` Integration**:
    *   Added `forceErrorText` to `FormBuilderField`, `FormBuilderFieldDecoration`, and core field constructors.
    *   This aligns the library with Flutter's updated `FormField` API (introduced in v3.24), allowing for declarative external error management.
3.  **Enhanced Documentation**:
    *   Updated docstrings for `validate()` and `invalidate()` to reflect the updated behavior regarding custom error clearing.

<details>
<summary>Code used for the demo</summary>

```dart
import 'package:flutter/material.dart';
import 'package:flutter_form_builder/flutter_form_builder.dart';
import 'package:form_builder_validators/form_builder_validators.dart';

void main() {
  runApp(const MaterialApp(home: SignupForm()));
}

class SignupForm extends StatefulWidget {
  const SignupForm({super.key});

  @override
  State<SignupForm> createState() => _SignupFormState();
}

class _SignupFormState extends State<SignupForm> {
  final _formKey = GlobalKey<FormBuilderState>();
  final _emailFieldKey = GlobalKey<FormBuilderFieldState>();
  AutovalidateMode autovalidateMode = AutovalidateMode.disabled;

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(title: const Text('Signup Form')),
      body: SingleChildScrollView(
        padding: const EdgeInsets.all(16.0),
        child: FormBuilder(
          key: _formKey,
          autovalidateMode: autovalidateMode,
          child: Column(
            children: [
              FormBuilderTextField(
                name: 'full_name',
                decoration: const InputDecoration(labelText: 'Full Name'),
                validator: FormBuilderValidators.compose([
                  FormBuilderValidators.required(),
                ]),
              ),
              const SizedBox(height: 10),
              FormBuilderTextField(
                key: _emailFieldKey,
                name: 'email',
                decoration: const InputDecoration(labelText: 'Email'),
                validator: FormBuilderValidators.compose([
                  FormBuilderValidators.required(),
                  FormBuilderValidators.email(),
                ]),
              ),
              const SizedBox(height: 10),
              FormBuilderTextField(
                name: 'password',
                decoration: const InputDecoration(labelText: 'Password'),
                obscureText: true,
                validator: FormBuilderValidators.compose([
                  FormBuilderValidators.required(),
                  FormBuilderValidators.minLength(6),
                ]),
              ),
              const SizedBox(height: 10),
              FormBuilderTextField(
                name: 'confirm_password',
                autovalidateMode: AutovalidateMode.onUserInteraction,
                decoration: InputDecoration(
                  labelText: 'Confirm Password',
                  suffixIcon: (_formKey.currentState?.fields['confirm_password']?.hasError ?? false)
                      ? const Icon(Icons.error, color: Colors.red)
                      : const Icon(Icons.check, color: Colors.green),
                ),
                obscureText: true,
                validator: (value) => _formKey.currentState?.fields['password']?.value != value ? 'No coinciden' : null,
              ),
              const SizedBox(height: 10),
              FormBuilderFieldDecoration<bool>(
                name: 'test',
                validator: FormBuilderValidators.compose([
                  FormBuilderValidators.required(),
                  FormBuilderValidators.equal(true),
                ]),
                // initialValue: true,
                decoration: const InputDecoration(labelText: 'Accept Terms?'),
                builder: (FormFieldState<bool?> field) {
                  return InputDecorator(
                    decoration: InputDecoration(
                      errorText: field.errorText,
                    ),
                    child: SwitchListTile(
                      title: const Text('I have read and accept the terms of service.'),
                      onChanged: field.didChange,
                      value: field.value ?? false,
                    ),
                  );
                },
              ),
              const SizedBox(height: 10),
              ElevatedButton(
                onPressed: () {
                  if (_formKey.currentState?.saveAndValidate() ?? false) {
                    if (true) {
                      // Either invalidate using Form Key
                      _formKey.currentState?.fields['email']?.invalidate('Email already taken.');
                      // OR invalidate using Field Key
                      // _emailFieldKey.currentState?.invalidate('Email already taken.');
                    }
                  } else {
                    setState(() {
                      autovalidateMode = AutovalidateMode.onUserInteraction;
                    });
                    debugPrint(_formKey.currentState?.value.toString());
                  }
                },
                child: const Text('Signup'),
              )
            ],
          ),
        ),
      ),
    );
  }
}
```

</details>

## Screenshots or Videos


https://github.com/user-attachments/assets/905deac2-d025-4507-9173-40dd24e89460


## To Do

- [x] Read contributing guide
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
