### PR TITLE
fix(field): #1370 isDirty flag reset on initialValue 

### DIFF
--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_form_builder/flutter_form_builder.dart';
 
@@ -185,13 +186,26 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
 
   void _informFormForFieldChange() {
     if (_formBuilderState != null) {
-      _dirty = value != initialValue;
+      _dirty = !_hasSameValue(value, initialValue);
       if (enabled || readOnly) {
         _formBuilderState!.setInternalFieldValue<T>(widget.name, value);
         return;
       }
       _formBuilderState!.removeInternalFieldValue(widget.name);
     }
+  }
+
+  bool _hasSameValue(T? currentValue, T? initialValue) {
+    if (currentValue is List && initialValue is List) {
+      return listEquals(currentValue, initialValue);
+    }
+    if (currentValue is Set && initialValue is Set) {
+      return setEquals(currentValue, initialValue);
+    }
+    if (currentValue is Map && initialValue is Map) {
+      return mapEquals(currentValue, initialValue);
+    }
+    return currentValue == initialValue;
   }
 
   void _touchedHandler() {

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -185,7 +185,7 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
 
   void _informFormForFieldChange() {
     if (_formBuilderState != null) {
-      _dirty = true;
+      _dirty = value != initialValue;
       if (enabled || readOnly) {
         _formBuilderState!.setInternalFieldValue<T>(widget.name, value);
         return;

--- a/lib/src/form_builder_field.dart
+++ b/lib/src/form_builder_field.dart
@@ -224,8 +224,8 @@ class FormBuilderFieldState<F extends FormBuilderField<T>, T>
   /// Also reset custom error text if exists, and set [isDirty] to `false`.
   void reset() {
     super.reset();
-    didChange(initialValue);
     _dirty = false;
+    didChange(initialValue);
     if (_customErrorText != null) {
       setState(() => _customErrorText = null);
     }

--- a/test/src/fields/form_builder_checkbox_group_test.dart
+++ b/test/src/fields/form_builder_checkbox_group_test.dart
@@ -166,6 +166,34 @@ void main() {
       expect(checkbox2.value, false);
       expect(checkbox3.value, true);
     });
+    testWidgets(
+      'Should not dirty when didChange receives a list matching initial contents',
+      (WidgetTester tester) async {
+        const fieldName = 'cbg1';
+        final testWidget = FormBuilderCheckboxGroup<int>(
+          name: fieldName,
+          options: const [
+            FormBuilderFieldOption(key: ValueKey('1'), value: 1),
+            FormBuilderFieldOption(key: ValueKey('2'), value: 2),
+            FormBuilderFieldOption(key: ValueKey('3'), value: 3),
+          ],
+        );
+        await tester.pumpWidget(
+          buildTestableFieldWidget(
+            testWidget,
+            initialValue: const {fieldName: [1, 3]},
+          ),
+        );
+
+        final state = formKey.currentState?.fields[fieldName];
+        expect(state?.isDirty, false);
+
+        formFieldDidChange(fieldName, [1, 3]);
+        await tester.pumpAndSettle();
+
+        expect(state?.isDirty, false);
+      },
+    );
     testWidgets('When press tab, field will be focused', (
       WidgetTester tester,
     ) async {

--- a/test/src/fields/form_builder_checkbox_group_test.dart
+++ b/test/src/fields/form_builder_checkbox_group_test.dart
@@ -181,7 +181,9 @@ void main() {
         await tester.pumpWidget(
           buildTestableFieldWidget(
             testWidget,
-            initialValue: const {fieldName: [1, 3]},
+            initialValue: const {
+              fieldName: [1, 3],
+            },
           ),
         );
 

--- a/test/src/form_builder_field_test.dart
+++ b/test/src/form_builder_field_test.dart
@@ -503,11 +503,13 @@ void main() {
     });
     group('reset -', () {
       testWidgets(
-        'Should avoid reset recursion when value returns to initial in onChanged',
+        'Should avoid reset recursion when reset is called after dirty state',
         (tester) async {
           const textFieldName = 'text';
           final textFieldKey = GlobalKey<FormBuilderFieldState>();
           var onChangedCalls = 0;
+          var onChangedCallsBeforeReset = 0;
+          bool? isDirtyInResetOnChanged;
           final testWidget = FormBuilderTextField(
             name: textFieldName,
             key: textFieldKey,
@@ -515,8 +517,8 @@ void main() {
             onChanged: (value) {
               onChangedCalls++;
               final state = textFieldKey.currentState;
-              if (value == state?.initialValue && state?.isDirty == true) {
-                state?.reset();
+              if (value == state?.initialValue) {
+                isDirtyInResetOnChanged = state?.isDirty;
               }
             },
           );
@@ -525,12 +527,18 @@ void main() {
           final widgetFinder = find.byWidget(testWidget);
           await tester.enterText(widgetFinder, 'test');
           await tester.pumpAndSettle();
-          await tester.enterText(widgetFinder, 'hi');
+
+          expect(textFieldKey.currentState?.isDirty, true);
+          onChangedCallsBeforeReset = onChangedCalls;
+
+          textFieldKey.currentState?.reset();
           await tester.pumpAndSettle();
 
           expect(tester.takeException(), isNull);
+          expect(textFieldKey.currentState?.value, equals('hi'));
           expect(textFieldKey.currentState?.isDirty, false);
-          expect(onChangedCalls, equals(2));
+          expect(onChangedCalls, equals(onChangedCallsBeforeReset + 1));
+          expect(isDirtyInResetOnChanged, isFalse);
         },
       );
       testWidgets('Should reset to null when call reset', (tester) async {

--- a/test/src/form_builder_field_test.dart
+++ b/test/src/form_builder_field_test.dart
@@ -503,13 +503,11 @@ void main() {
     });
     group('reset -', () {
       testWidgets(
-        'Should avoid reset recursion when reset is called after dirty state',
+        'Should avoid reset recursion when value returns to initial in onChanged',
         (tester) async {
           const textFieldName = 'text';
           final textFieldKey = GlobalKey<FormBuilderFieldState>();
           var onChangedCalls = 0;
-          var onChangedCallsBeforeReset = 0;
-          bool? isDirtyInResetOnChanged;
           final testWidget = FormBuilderTextField(
             name: textFieldName,
             key: textFieldKey,
@@ -517,8 +515,8 @@ void main() {
             onChanged: (value) {
               onChangedCalls++;
               final state = textFieldKey.currentState;
-              if (value == state?.initialValue) {
-                isDirtyInResetOnChanged = state?.isDirty;
+              if (value == state?.initialValue && state?.isDirty == true) {
+                state?.reset();
               }
             },
           );
@@ -527,18 +525,12 @@ void main() {
           final widgetFinder = find.byWidget(testWidget);
           await tester.enterText(widgetFinder, 'test');
           await tester.pumpAndSettle();
-
-          expect(textFieldKey.currentState?.isDirty, true);
-          onChangedCallsBeforeReset = onChangedCalls;
-
-          textFieldKey.currentState?.reset();
+          await tester.enterText(widgetFinder, 'hi');
           await tester.pumpAndSettle();
 
           expect(tester.takeException(), isNull);
-          expect(textFieldKey.currentState?.value, equals('hi'));
           expect(textFieldKey.currentState?.isDirty, false);
-          expect(onChangedCalls, equals(onChangedCallsBeforeReset + 1));
-          expect(isDirtyInResetOnChanged, isFalse);
+          expect(onChangedCalls, equals(2));
         },
       );
       testWidgets('Should reset to null when call reset', (tester) async {

--- a/test/src/form_builder_field_test.dart
+++ b/test/src/form_builder_field_test.dart
@@ -419,6 +419,27 @@ void main() {
           expect(textFieldKey.currentState?.isDirty, true);
         },
       );
+      testWidgets('Should not dirty when value returns to initial by user', (
+        tester,
+      ) async {
+        const textFieldName = 'text';
+        final textFieldKey = GlobalKey<FormBuilderFieldState>();
+        final testWidget = FormBuilderTextField(
+          name: textFieldName,
+          key: textFieldKey,
+          initialValue: 'hi',
+        );
+        await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+        final widgetFinder = find.byWidget(testWidget);
+        await tester.enterText(widgetFinder, 'test');
+        await tester.pumpAndSettle();
+        expect(textFieldKey.currentState?.isDirty, true);
+
+        await tester.enterText(widgetFinder, 'hi');
+        await tester.pumpAndSettle();
+        expect(textFieldKey.currentState?.isDirty, false);
+      });
       testWidgets('Should not dirty when reset field value', (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();
@@ -481,6 +502,37 @@ void main() {
       });
     });
     group('reset -', () {
+      testWidgets(
+        'Should avoid reset recursion when value returns to initial in onChanged',
+        (tester) async {
+          const textFieldName = 'text';
+          final textFieldKey = GlobalKey<FormBuilderFieldState>();
+          var onChangedCalls = 0;
+          final testWidget = FormBuilderTextField(
+            name: textFieldName,
+            key: textFieldKey,
+            initialValue: 'hi',
+            onChanged: (value) {
+              onChangedCalls++;
+              final state = textFieldKey.currentState;
+              if (value == state?.initialValue && state?.isDirty == true) {
+                state?.reset();
+              }
+            },
+          );
+          await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+          final widgetFinder = find.byWidget(testWidget);
+          await tester.enterText(widgetFinder, 'test');
+          await tester.pumpAndSettle();
+          await tester.enterText(widgetFinder, 'hi');
+          await tester.pumpAndSettle();
+
+          expect(tester.takeException(), isNull);
+          expect(textFieldKey.currentState?.isDirty, false);
+          expect(onChangedCalls, equals(2));
+        },
+      );
       testWidgets('Should reset to null when call reset', (tester) async {
         const textFieldName = 'text';
         final textFieldKey = GlobalKey<FormBuilderFieldState>();

--- a/test/src/form_builder_test.dart
+++ b/test/src/form_builder_test.dart
@@ -444,6 +444,27 @@ void main() {
 
       expect(formKey.currentState?.isDirty, true);
     });
+    testWidgets('Should not dirty when value returns to initial by user', (
+      tester,
+    ) async {
+      const textFieldName = 'text';
+      final testWidget = FormBuilderTextField(name: textFieldName);
+      await tester.pumpWidget(
+        buildTestableFieldWidget(
+          testWidget,
+          initialValue: {textFieldName: 'hi'},
+        ),
+      );
+
+      final widgetFinder = find.byWidget(testWidget);
+      await tester.enterText(widgetFinder, 'test');
+      await tester.pumpAndSettle();
+      expect(formKey.currentState?.isDirty, true);
+
+      await tester.enterText(widgetFinder, 'hi');
+      await tester.pumpAndSettle();
+      expect(formKey.currentState?.isDirty, false);
+    });
     testWidgets('Should dirty when update field with initial value by method', (
       tester,
     ) async {


### PR DESCRIPTION
## Connection with issue(s)

<!-- If this pull request close some issue, use this reference to close it automatically -->
Close #1370

<!-- Optional: other issues or pull requests related to this, but merging should not close it -->

## Solution description

* Reset isDirty flag if the current value in a form field matches the defined initial value.  
* Corresponding tests

## Screenshots or Videos

<!-- Optional: to clearly demonstrate the feature or fix to help with testing and reviews -->

## To Do

- [x] Read [contributing guide](https://github.com/flutter-form-builder-ecosystem/.github/blob/main/CONTRIBUTING.md)
- [x] Check the original issue to confirm it is fully satisfied
- [x] Add solution description to help guide reviewers
- [x] Add unit test to verify new or fixed behaviour
- [x] If apply, add documentation to code properties and package readme
