### PR TITLE
docs: document DateFormat source #1463

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Also included are common ready-made form input fields for FormBuilder. This give
   - [Basic use](#basic-use)
   - [Specific uses](#specific-uses)
     - [Validate and get values](#validate-and-get-values)
+    - [Format date and time values](#format-date-and-time-values)
     - [Building your own custom field](#building-your-own-custom-field)
     - [Programmatically changing field value](#programmatically-changing-field-value)
     - [Programmatically inducing an error](#programmatically-inducing-an-error)
@@ -157,6 +158,22 @@ FormBuilder(
 For a complete example that enables or disables the submit button from form
 state and validates an email field conditionally, see
 [Submit Button State](example/lib/sources/submit_button.dart).
+
+#### Format date and time values
+
+`FormBuilderDateTimePicker.format` expects a
+[`DateFormat`](https://pub.dev/documentation/intl/latest/intl/DateFormat-class.html)
+from the [`intl`](https://pub.dev/packages/intl) package.
+
+```dart
+import 'package:intl/intl.dart';
+
+FormBuilderDateTimePicker(
+  name: 'date',
+  inputType: InputType.date,
+  format: DateFormat('yyyy-MM-dd'),
+)
+```
 
 #### Building your own custom field
 

--- a/lib/src/fields/form_builder_date_time_picker.dart
+++ b/lib/src/fields/form_builder_date_time_picker.dart
@@ -18,9 +18,12 @@ class FormBuilderDateTimePicker extends FormBuilderFieldDecoration<DateTime> {
   /// picker(s) will be shown every time the field gains focus.
   // final bool editable;
 
-  /// For representing the date as a string e.g.
+  /// For representing the date as a string.
+  ///
+  /// Use [DateFormat](https://pub.dev/documentation/intl/latest/intl/DateFormat-class.html)
+  /// from the `intl` package, e.g.
   /// `DateFormat("EEEE, MMMM d, yyyy 'at' h:mma")`
-  /// (Sunday, June 3, 2018 at 9:24pm)
+  /// (Sunday, June 3, 2018 at 9:24pm).
   final DateFormat? format;
 
   /// The date the calendar opens to when displayed. Defaults to null.


### PR DESCRIPTION
## Summary
- Documents that `FormBuilderDateTimePicker.format` uses `DateFormat` from the `intl` package.
- Adds a README example showing the required `package:intl/intl.dart` import and a custom date format.
- Adds a direct API-doc link to the `DateFormat` class so users can find the type definition from generated docs.

Closes #1463

## Verification
- `dart format .`
- `flutter analyze`
- `flutter test`

## Notes
- This keeps the change documentation-only rather than re-exporting `DateFormat`, which avoids changing the public API surface.