### PR TITLE
fix: reset an unknown initialValue on first build in FormBuilderDropdown (#1363)

### DIFF
--- a/lib/src/fields/form_builder_dropdown.dart
+++ b/lib/src/fields/form_builder_dropdown.dart
@@ -348,6 +348,12 @@ class FormBuilderDropdown<T> extends FormBuilderFieldDecoration<T> {
 class _FormBuilderDropdownState<T>
     extends FormBuilderFieldDecorationState<FormBuilderDropdown<T>, T> {
   @override
+  void initState() {
+    super.initState();
+    _resetUnknownInitialValue();
+  }
+
+  @override
   void didUpdateWidget(covariant FormBuilderDropdown<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
 
@@ -358,22 +364,30 @@ class _FormBuilderDropdownState<T>
         .map((e) => e.child.toString())
         .toList();
 
-    if (!currentlyValues.contains(initialValue) &&
-        !initialValue.emptyValidator()) {
-      assert(
-        currentlyValues.contains(initialValue) && initialValue.emptyValidator(),
-        'The initialValue [$initialValue] is not in the list of items or is not null or empty. '
-        'Please provide one of the items as the initialValue or update your initial value. '
-        'By default, will apply [null] to field value',
-      );
-      setValue(null);
-    }
+    _resetUnknownInitialValue();
 
     if ((!listEquals(oldChilds, currentlyChilds) ||
             !listEquals(oldValues, currentlyValues)) &&
         (currentlyValues.contains(initialValue) ||
             initialValue.emptyValidator())) {
       setValue(initialValue);
+    }
+  }
+
+  /// Asserts when [initialValue] is not among the current items, like
+  /// [DropdownButton] does for its `value`. On release builds, where asserts
+  /// are disabled, falls back to a null value so an unselectable value is
+  /// never kept in the form state.
+  void _resetUnknownInitialValue() {
+    final values = widget.items.map((e) => e.value).toList();
+    if (!values.contains(initialValue) && !initialValue.emptyValidator()) {
+      assert(
+        values.contains(initialValue) && initialValue.emptyValidator(),
+        'The initialValue [$initialValue] is not in the list of items or is not null or empty. '
+        'Please provide one of the items as the initialValue or update your initial value. '
+        'By default, will apply [null] to field value',
+      );
+      setValue(null);
     }
   }
 }

--- a/test/src/fields/form_builder_dropdown_test.dart
+++ b/test/src/fields/form_builder_dropdown_test.dart
@@ -220,6 +220,41 @@ void main() {
       expect(formSave(), isTrue);
       expect(formValue(widgetName), equals(2));
     });
+    testWidgets('asserts when initial value is not in items', (
+      WidgetTester tester,
+    ) async {
+      const widgetName = 'dropdown_field';
+
+      final testWidget = FormBuilderDropdown<int>(
+        name: widgetName,
+        initialValue: 3,
+        items: const [
+          DropdownMenuItem(value: 1, child: Text('Option 1')),
+          DropdownMenuItem(value: 2, child: Text('Option 2')),
+        ],
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+      expect(tester.takeException(), isAssertionError);
+    });
+    testWidgets('asserts when form initial value is not in items', (
+      WidgetTester tester,
+    ) async {
+      const widgetName = 'dropdown_field';
+
+      final testWidget = FormBuilderDropdown<int>(
+        name: widgetName,
+        items: const [
+          DropdownMenuItem(value: 1, child: Text('Option 1')),
+          DropdownMenuItem(value: 2, child: Text('Option 2')),
+        ],
+      );
+      await tester.pumpWidget(
+        buildTestableFieldWidget(testWidget, initialValue: {widgetName: 3}),
+      );
+
+      expect(tester.takeException(), isAssertionError);
+    });
   });
   testWidgets('Should reset to null when call reset', (tester) async {
     const widgetName = 'dropdown_field';


### PR DESCRIPTION
# fix: #1363 FormBuilderDropdown silently ignores an unknown initialValue

Fixes #1363

## What breaks

`FormBuilderDropdown` accepts an `initialValue` that is not among `items`. The button renders empty, but the value stays in the field state and `saveAndValidate()` returns it as if the user had selected it. A `required` validator even passes, so the form submits a value the user could never pick.

## Root cause

The unknown-initial-value check (assert plus null fallback) only exists in `didUpdateWidget`, so it runs when the widget is rebuilt with new items but never on first build. On first build the field registers with the unknown value and the builder hides it (`value: hasValue ? field.value : null`), which also prevents `DropdownButton`'s own assertion from firing.

## Fix

Run the same check on first build. I extracted the existing block from `didUpdateWidget` into `_resetUnknownInitialValue()` and call it from both `initState` and `didUpdateWidget`. The behavior matches the existing update path: in debug mode an assertion fires, the same way `DropdownButton` asserts on a value outside its items; in release mode, where asserts are disabled, the field value falls back to null so an unselectable value is never kept in form state. The update path itself is unchanged.

## Tests

Two new widget tests in `form_builder_dropdown_test.dart`: one with a widget-level `initialValue` not in items, one with a `FormBuilder`-level initial value map entry not in items. Both expect the assertion on first build. Both fail on current main and pass with the fix. The full test suite (148 tests), `dart analyze`, and `dart format` all pass.
