### PR TITLE
fix: remove focus() from FormBuilderCheckbox.didChange (#1495)

### DIFF
--- a/lib/src/fields/form_builder_checkbox.dart
+++ b/lib/src/fields/form_builder_checkbox.dart
@@ -178,10 +178,4 @@ class _FormBuilderCheckboxState
     effectiveFocusNode.removeListener(handleFocusChange);
     super.dispose();
   }
-
-  @override
-  void didChange(bool? value) {
-    focus();
-    super.didChange(value);
-  }
 }

--- a/test/src/fields/form_builder_checkbox_test.dart
+++ b/test/src/fields/form_builder_checkbox_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_form_builder/src/fields/form_builder_checkbox.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
 import 'package:flutter_test/flutter_test.dart';
 import '../../form_builder_tester.dart';
 
@@ -52,5 +52,60 @@ void main() {
       expect(Focus.of(tester.element(widgetFinder)).hasFocus, true);
       expect(focusNode?.hasFocus, true);
     });
+    // Regression test for https://github.com/flutter-form-builder-ecosystem/flutter_form_builder/issues/1495
+    testWidgets(
+      'Programmatic didChange does not steal focus from another field',
+      (WidgetTester tester) async {
+        const textFieldName = 'text';
+        const checkboxName = 'checkbox';
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: FormBuilder(
+                key: formKey,
+                child: Column(
+                  children: [
+                    FormBuilderTextField(
+                      name: textFieldName,
+                      onChanged: (v) {
+                        formKey.currentState?.fields[checkboxName]
+                            ?.didChange(true);
+                      },
+                    ),
+                    FormBuilderCheckbox(
+                      name: checkboxName,
+                      title: const Text('Checkbox'),
+                      initialValue: false,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+
+        // Tap the text field to focus it
+        await tester.tap(find.byType(TextField));
+        await tester.pumpAndSettle();
+
+        final textFocusNode =
+            formKey.currentState?.fields[textFieldName]?.effectiveFocusNode;
+        final checkboxFocusNode =
+            formKey.currentState?.fields[checkboxName]?.effectiveFocusNode;
+
+        expect(textFocusNode?.hasFocus, isTrue);
+        expect(checkboxFocusNode?.hasFocus, isFalse);
+
+        // Type text — triggers onChanged which calls checkbox.didChange(true)
+        await tester.enterText(find.byType(TextField), 'hello');
+        await tester.pumpAndSettle();
+
+        // The checkbox value should update but focus must stay on the text field
+        expect(formKey.currentState?.fields[checkboxName]?.value, isTrue);
+        expect(textFocusNode?.hasFocus, isTrue);
+        expect(checkboxFocusNode?.hasFocus, isFalse);
+      },
+    );
   });
 }

--- a/test/src/fields/form_builder_checkbox_test.dart
+++ b/test/src/fields/form_builder_checkbox_test.dart
@@ -69,8 +69,9 @@ void main() {
                     FormBuilderTextField(
                       name: textFieldName,
                       onChanged: (v) {
-                        formKey.currentState?.fields[checkboxName]
-                            ?.didChange(true);
+                        formKey.currentState?.fields[checkboxName]?.didChange(
+                          true,
+                        );
                       },
                     ),
                     FormBuilderCheckbox(


### PR DESCRIPTION
## Problem

`FormBuilderCheckbox.didChange()` unconditionally calls `focus()`, stealing focus from other fields when the value is changed programmatically.

**Reproduction (from issue):** A `FormBuilderTextField`'s `onChanged` calls `didChange(true)` on a checkbox — the text field loses focus mid-typing.

## Root Cause

`_FormBuilderCheckboxState` overrides `didChange` to call `focus()` before `super.didChange(value)`. This was likely added for keyboard accessibility, but `CheckboxListTile` already handles focus on direct user taps via the `focusNode` parameter passed in the builder.

## Fix

Remove the `didChange` override entirely. The `handleFocusChange` listener (for `InputDecorator.isFocused` rebuilds) is preserved.

This aligns `FormBuilderCheckbox` with `FormBuilderSwitch`, which does not override `didChange`.

## Test

Added a regression test that reproduces the exact scenario from the issue — a text field whose `onChanged` programmatically calls `didChange` on a checkbox — and asserts the text field retains focus.

- `flutter analyze`: no issues
- `flutter test`: 149/149 passed

Fixes #1495