### PR TITLE
test: cover AutovalidateMode.onUserInteractionIfError passthrough #1504

### DIFF
--- a/test/src/form_builder_test.dart
+++ b/test/src/form_builder_test.dart
@@ -675,6 +675,78 @@ void main() {
       expect(formKey.currentState?.fields, contains(secondDropdownName));
     });
   });
+
+  group('AutovalidateMode.onUserInteractionIfError -', () {
+    // The mode landed via flutter/flutter#175515. The runtime lookup keeps the
+    // package compatible with older stable versions: there the tests just pass
+    // without exercising the mode.
+    final onUserInteractionIfError = AutovalidateMode.values
+        .asNameMap()['onUserInteractionIfError'];
+
+    testWidgets('form level: validates only after the first failed validate', (
+      WidgetTester tester,
+    ) async {
+      if (onUserInteractionIfError == null) {
+        return;
+      }
+      const widgetName = 'name';
+      final testWidget = FormBuilderTextField(
+        name: widgetName,
+        validator: (value) =>
+            value == null || value.isEmpty ? 'required' : null,
+      );
+      await tester.pumpWidget(
+        buildTestableFieldWidget(
+          testWidget,
+          autovalidateMode: onUserInteractionIfError,
+        ),
+      );
+
+      await tester.enterText(find.byWidget(testWidget), 'a');
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byWidget(testWidget), '');
+      await tester.pumpAndSettle();
+      expect(find.text('required'), findsNothing);
+
+      expect(formSave(), isFalse);
+      await tester.pumpAndSettle();
+      expect(find.text('required'), findsOneWidget);
+
+      await tester.enterText(find.byWidget(testWidget), 'ok');
+      await tester.pumpAndSettle();
+      expect(find.text('required'), findsNothing);
+    });
+
+    testWidgets('field level: validates only after the first failed validate', (
+      WidgetTester tester,
+    ) async {
+      if (onUserInteractionIfError == null) {
+        return;
+      }
+      const widgetName = 'name';
+      final testWidget = FormBuilderTextField(
+        name: widgetName,
+        autovalidateMode: onUserInteractionIfError,
+        validator: (value) =>
+            value == null || value.isEmpty ? 'required' : null,
+      );
+      await tester.pumpWidget(buildTestableFieldWidget(testWidget));
+
+      await tester.enterText(find.byWidget(testWidget), 'a');
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byWidget(testWidget), '');
+      await tester.pumpAndSettle();
+      expect(find.text('required'), findsNothing);
+
+      expect(formKey.currentState!.fields[widgetName]!.validate(), isFalse);
+      await tester.pumpAndSettle();
+      expect(find.text('required'), findsOneWidget);
+
+      await tester.enterText(find.byWidget(testWidget), 'ok');
+      await tester.pumpAndSettle();
+      expect(find.text('required'), findsNothing);
+    });
+  });
 }
 
 // simple stateful widget that can hide and show its child with the intent of


### PR DESCRIPTION
Closes #1504

Investigation result: no package change is needed for the new mode. `FormBuilder` hands `autovalidateMode` to the underlying `Form` untouched, and every field passes it through to `FormField`, so `AutovalidateMode.onUserInteractionIfError` (flutter/flutter#175515, in current stable) already works at both levels. Nothing in our own validation triggers interferes: the only special-cased mode is `always` (initial validate in `initState`).

This adds behavior tests pinning that down at the form level and the field level: no validation before the first failed `validate()`, error appears after it, and the error clears on the next user interaction.

The tests look the mode up with `AutovalidateMode.values.asNameMap()`, so the package keeps supporting Flutter 3.38: on older stables the tests simply pass without exercising the mode, and no minimum version bump is required.
